### PR TITLE
Add comment on `MAX_SYSTEM_CONTRACT_ADDRESS` choice

### DIFF
--- a/contracts/Constants.sol
+++ b/contracts/Constants.sol
@@ -18,7 +18,8 @@ import "./BootloaderUtilities.sol";
 uint160 constant SYSTEM_CONTRACTS_OFFSET = 0x8000; // 2^15
 
 /// @dev All the system contracts must be located in the kernel space,
-/// i.e. their addresses must be below 2^16.
+/// i.e. their addresses must be below 2^16. The motivation behind this
+/// choice is EIP-1352: https://eips.ethereum.org/EIPS/eip-1352.
 uint160 constant MAX_SYSTEM_CONTRACT_ADDRESS = 0xffff; // 2^16 - 1
 
 address constant ECRECOVER_SYSTEM_CONTRACT = address(0x01);


### PR DESCRIPTION
I assume the choice behind the constant `MAX_SYSTEM_CONTRACT_ADDRESS` is [EIP-1352](https://eips.ethereum.org/EIPS/eip-1352). Thus, I think it's a good idea to document it. Another point I would like to raise is that the maximum number of reserved addresses for precompiles and system contracts is actually `0x10000` (65,536) and not `0xffff` (65535) since the address range between `0x0000000000000000000000000000000000000000` and `0x000000000000000000000000000000000000ffff` is reserved (including the `0x0` address). My question would be if there is a specific reasoning on not following exactly this threshold.