### PR TITLE
Support 2048 leaves tree and remove unneeded forced upgrade

### DIFF
--- a/bootloader/bootloader.yul
+++ b/bootloader/bootloader.yul
@@ -632,36 +632,6 @@ object "Bootloader" {
                     }
             }
 
-            /// @dev Checks whether the code hash of the system context contract is correct and updates it if needed.
-            /// @dev The bootloader implementation strictly relies of the ability of the system context contract to work with the 
-            /// L2 blocks. However, the old system context did not support the correspodning interface at all. Usually we upgrade system context
-            /// via an upgrade transaction, but in this case the transaction won't be even processed, because of failure to create an L2 block.
-            function upgradeSystemContextIfNeeded() {
-                let expectedCodeHash := {{SYSTEM_CONTEXT_EXPECTED_CODE_HASH}}
-                
-                let actualCodeHash := extcodehash(SYSTEM_CONTEXT_ADDR())
-                if iszero(eq(expectedCodeHash, actualCodeHash)) {
-                    // Preparing the calldata to upgrade the SystemContext contract
-                    {{UPGRADE_SYSTEM_CONTEXT_CALLDATA}}
-                    
-                    // We'll use a mimicCall to simulate the correct sender.
-                    let success := mimicCallOnlyResult(
-                        CONTRACT_DEPLOYER_ADDR(),
-                        FORCE_DEPLOYER(), 
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0
-                    )
-
-                    if iszero(success) {
-                        assertionError("system context upgrade fail")
-                    }
-                }
-            }
-
             /// @dev Calculates the canonical hash of the L1->L2 transaction that will be
             /// sent to L1 as a message to the L1 contract that a certain operation has been processed.
             function getCanonicalL1TxHash(txDataOffset) -> ret {
@@ -3654,11 +3624,6 @@ object "Bootloader" {
                 let EXPECTED_BASE_FEE := mload(192)
 
                 validateOperatorProvidedPrices(L1_GAS_PRICE, FAIR_L2_GAS_PRICE)
-
-                // This implementation of the bootloader relies on the correct version of the SystemContext
-                // and it can not be upgraded via a standard upgrade transaction, but needs to ensure 
-                // correctness itself before any transaction is executed. 
-                upgradeSystemContextIfNeeded()
 
                 let baseFee := 0
 

--- a/contracts/Constants.sol
+++ b/contracts/Constants.sol
@@ -93,3 +93,7 @@ enum SystemLogKey {
     NUMBER_OF_LAYER_1_TXS_KEY,
     EXPECTED_SYSTEM_CONTRACT_UPGRADE_TX_HASH
 }
+
+/// @dev The number of leaves in the L2->L1 log Merkle tree. 
+/// While formally a tree of any length is acceptable, the node supports only a constant length of 2048 leaves.
+uint256 constant L2_TO_L1_LOGS_MERKLE_TREE_LEAVES = 2048;

--- a/contracts/interfaces/IMailbox.sol
+++ b/contracts/interfaces/IMailbox.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 
 interface IMailbox {
     function finalizeEthWithdrawal(
-        uint256 _l2BlockNumber,
+        uint256 _l2BatchNumber,
         uint256 _l2MessageIndex,
         uint16 _l2TxNumberInBlock,
         bytes calldata _message,


### PR DESCRIPTION
# What ❔

- The maximal & default size of L2->L1 logs now is 2048.
- The upgrade mechanism that was required for the virtual block migration is no longer needed.

## Why ❔

- We can now support any L2->L1 log tree, but due to the server requirements, 2048 will be for now as the constant.
- The upgrade mechanism for the system context is not needed anymore and so can be removed to avoid dead code
 
## Checklist

- [+] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [+] Tests for the changes have been added / updated.
- [+] Documentation comments have been added / updated.
- [+] Code has been formatted via `zk fmt` and `zk lint`.
