### PR TITLE
Pubdata compression

### DIFF
--- a/contracts/Compressor.sol
+++ b/contracts/Compressor.sol
@@ -106,7 +106,7 @@ contract Compressor is ICompressor, ISystemContract {
                 require(derivedKey == _compressedStateDiffs.readBytes32(stateDiffPtr), "iw: initial key mismatch");
                 stateDiffPtr += 32;
                 uint8 metadata = uint8(bytes1(_compressedStateDiffs[stateDiffPtr]));
-                stateDiffPtr += 1;
+                stateDiffPtr++;
                 uint8 operation = metadata & OPERATION_BITMASK;
                 uint8 len = operation == 0 ? 32 : metadata >> LENGTH_BITS_OFFSET;
                 _verifyValueCompression(
@@ -180,14 +180,16 @@ contract Compressor is ICompressor, ISystemContract {
         uint256 convertedValue = uint256(bytes32(_compressedValue));
         convertedValue >>= (256 - (_compressedValue.length * 8));
 
-        if (_operation == 0 || _operation == 3) {
-            require(convertedValue == _finalValue);
-        } else if (_operation == 1) {
-            require(_initialValue + convertedValue == _finalValue);
-        } else if (_operation == 2) {
-            require(_initialValue - convertedValue == _finalValue);
-        } else {
-            revert("unsupported operation");
+        unchecked {
+            if (_operation == 0 || _operation == 3) {
+                require(convertedValue == _finalValue, "transform or no compression: compressed and final mismatch");
+            } else if (_operation == 1) {
+                require(_initialValue + convertedValue == _finalValue, "add: initial plus converted not equal to final");
+            } else if (_operation == 2) {
+                require(_initialValue - convertedValue == _finalValue, "sub: initial minus converted not equal to final");
+            } else {
+                revert("unsupported operation");
+            }
         }
     }
 }

--- a/contracts/Compressor.sol
+++ b/contracts/Compressor.sol
@@ -165,7 +165,7 @@ contract Compressor is ICompressor, ISystemContract {
 
         require(stateDiffPtr == _compressedStateDiffs.length, "Extra data in _compressedStateDiffs");
 
-        stateDiffHash = keccak256(_stateDiffs);
+        stateDiffHash = EfficientCall.keccak(_stateDiffs);
     }
 
     /// @notice Decode the raw compressed data into the dictionary and the encoded data.

--- a/contracts/Compressor.sol
+++ b/contracts/Compressor.sol
@@ -109,7 +109,7 @@ contract Compressor is ICompressor, ISystemContract {
         // We do not enforce the operator to use the optimal, i.e. the minimally possible _enumerationIndexSize. 
         // We do enforce however, that the _enumerationIndexSize is not larger than 8 bytes long, which is the 
         // maximal ever possible size for enumeration index.
-        require(_enumerationIndexSize <= 8, "enumeration index size is too large");
+        require(_enumerationIndexSize <= MAX_ENUMERATION_INDEX_SIZE, "enumeration index size is too large");
 
         uint256 numberOfInitialWrites = uint256(_compressedStateDiffs.readUint16(0));
 

--- a/contracts/Compressor.sol
+++ b/contracts/Compressor.sol
@@ -118,6 +118,7 @@ contract Compressor is ICompressor, ISystemContract {
 
         // Process initial writes
         for (uint256 i = 0; i < _numberOfStateDiffs * STATE_DIFF_ENTRY_SIZE; i += STATE_DIFF_ENTRY_SIZE) {
+            bytes calldata stateDiff = _stateDiffs[i:i + STATE_DIFF_ENTRY_SIZE];
             uint64 enumIndex = stateDiff.readUint64(84);
             if (enumIndex != 0) {
                 // It is a repeated write, so we skip it.
@@ -126,7 +127,6 @@ contract Compressor is ICompressor, ISystemContract {
 
             numInitialWritesProcessed++;
 
-            bytes calldata stateDiff = _stateDiffs[i:i + STATE_DIFF_ENTRY_SIZE];
             bytes32 derivedKey = stateDiff.readBytes32(52);
             uint256 initValue = stateDiff.readUint256(92);
             uint256 finalValue = stateDiff.readUint256(124);
@@ -150,12 +150,12 @@ contract Compressor is ICompressor, ISystemContract {
 
         // Process repeated writes
         for (uint256 i = 0; i < _numberOfStateDiffs * STATE_DIFF_ENTRY_SIZE; i += STATE_DIFF_ENTRY_SIZE) {
+            bytes calldata stateDiff = _stateDiffs[i:i + STATE_DIFF_ENTRY_SIZE];
             uint64 enumIndex = stateDiff.readUint64(84);
             if (enumIndex == 0) {
                 continue;
             }
 
-            bytes calldata stateDiff = _stateDiffs[i:i + STATE_DIFF_ENTRY_SIZE];
             uint256 initValue = stateDiff.readUint256(92);
             uint256 finalValue = stateDiff.readUint256(124);
             uint256 compressedEnumIndex = _sliceToUint256(_compressedStateDiffs[stateDiffPtr:stateDiffPtr + _enumerationIndexSize]);

--- a/contracts/Compressor.sol
+++ b/contracts/Compressor.sol
@@ -105,7 +105,7 @@ contract Compressor is ICompressor, ISystemContract {
         uint256 _enumerationIndexSize,
         bytes calldata _stateDiffs,
         bytes calldata _compressedStateDiffs
-    ) external payable returns (bytes32 stateDiffHash) {
+    ) external payable onlyCallFrom(address(L1_MESSENGER_CONTRACT)) returns (bytes32 stateDiffHash) {
         uint256 numberOfInitialWrites = uint256(_compressedStateDiffs.readUint16(0));
 
         uint256 stateDiffPtr = 2;

--- a/contracts/Compressor.sol
+++ b/contracts/Compressor.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import {ICompressor} from "./interfaces/ICompressor.sol";
+import {ICompressor, OPERATION_BITMASK, LENGTH_BITS_OFFSET, MAX_ENUMERATION_INDEX_SIZE} from "./interfaces/ICompressor.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";
 import {Utils} from "./libraries/Utils.sol";
 import {UnsafeBytesCalldata} from "./libraries/UnsafeBytesCalldata.sol";

--- a/contracts/Constants.sol
+++ b/contracts/Constants.sol
@@ -79,8 +79,8 @@ bytes32 constant CREATE_PREFIX = 0x63bae3a9951d38e8a3fbb7b70909afc1200610fc5bc55
 
 uint256 constant STATE_DIFF_ENTRY_SIZE = 156;
 
-/// @dev While the "real" amount of pubdata that can be sent rarely exceeds the 110k - 120k, it is better to 
-/// allow the operator to provide any reasonably large value in order to avoid unneeded constraints on the operator.  
+/// @dev While the "real" amount of pubdata that can be sent rarely exceeds the 110k - 120k, it is better to
+/// allow the operator to provide any reasonably large value in order to avoid unneeded constraints on the operator.
 uint256 constant MAX_ALLOWED_PUBDATA_PER_BATCH = 520000;
 
 enum SystemLogKey {

--- a/contracts/L1Messenger.sol
+++ b/contracts/L1Messenger.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import {IL1Messenger, L2ToL1Log, L2_L1_LOGS_TREE_DEFAULT_LEAF_HASH, L2_TO_L1_LOG_SERIALIZE_SIZE} from "./interfaces/IL1Messenger.sol";
+import {IL1Messenger, L2ToL1Log, L2_L1_LOGS_TREE_DEFAULT_LEAF_HASH, L2_TO_L1_LOG_SERIALIZE_SIZE, STATE_DIFF_COMPRESSION_VERSION_NUMBER} from "./interfaces/IL1Messenger.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";
 import {SystemContractHelper} from "./libraries/SystemContractHelper.sol";
 import {EfficientCall} from "./libraries/EfficientCall.sol";

--- a/contracts/SystemContext.sol
+++ b/contracts/SystemContext.sol
@@ -60,11 +60,11 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
     bytes32 internal currentL2BlockTxsRollingHash;
 
     /// @notice The hashes of L2 blocks.
-    /// @dev It stores block hashes for previous L2 blocks. Note, in order to make publishing the hashes 
-    /// of the miniblocks cheaper, we only store the previous MINIBLOCK_HASHES_TO_STORE ones. Since whenever we need to publish a state 
+    /// @dev It stores block hashes for previous L2 blocks. Note, in order to make publishing the hashes
+    /// of the miniblocks cheaper, we only store the previous MINIBLOCK_HASHES_TO_STORE ones. Since whenever we need to publish a state
     /// diff, a pair of <key, value> is published and for cached keys only 8-byte id is used instead of 32 bytes.
     /// By having this data in a cyclic array of MINIBLOCK_HASHES_TO_STORE blocks, we bring the costs down by 40% (i.e. 40 bytes per miniblock instead of 64 bytes).
-    /// @dev The hash of a miniblock with number N would be stored under slot N%MINIBLOCK_HASHES_TO_STORE. 
+    /// @dev The hash of a miniblock with number N would be stored under slot N%MINIBLOCK_HASHES_TO_STORE.
     /// @dev Hashes of the blocks older than the ones which are stored here can be calculated as _calculateLegacyL2BlockHash(blockNumber).
     bytes32[MINIBLOCK_HASHES_TO_STORE] internal l2BlockHash;
 
@@ -96,7 +96,7 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
     /// @notice The method that emulates `blockhash` opcode in EVM.
     /// @dev Just like the blockhash in the EVM, it returns bytes32(0),
     /// when queried about hashes that are older than 256 blocks ago.
-    /// @dev Since zksolc compiler calls this method to emulate `blockhash`, 
+    /// @dev Since zksolc compiler calls this method to emulate `blockhash`,
     /// its signature can not be changed to `getL2BlockHashEVM`.
     /// @return hash The blockhash of the block with the given number.
     function getBlockHashEVM(uint256 _block) external view returns (bytes32 hash) {
@@ -106,7 +106,7 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
 
         // Due to virtual blocks upgrade, we'll have to use the following logic for retreiving the blockhash:
         // 1. If the block number is out of the 256-block supported range, return 0.
-        // 2. If the block was created before the upgrade for the virtual blocks (i.e. there we used to use hashes of the batches), 
+        // 2. If the block was created before the upgrade for the virtual blocks (i.e. there we used to use hashes of the batches),
         // we return the hash of the batch.
         // 3. If the block was created after the day when the virtual blocks have caught up with the L2 blocks, i.e.
         // all the information which is returned for users should be for L2 blocks, we return the hash of the corresponding L2 block.
@@ -117,11 +117,14 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
             // Note, that we will get into this branch only for a brief moment of time, right after the upgrade
             // for virtual blocks before 256 virtual blocks are produced.
             hash = batchHash[_block];
-        } else if (_block >= currentVirtualBlockUpgradeInfo.virtualBlockFinishL2Block && currentVirtualBlockUpgradeInfo.virtualBlockFinishL2Block > 0) {
+        } else if (
+            _block >= currentVirtualBlockUpgradeInfo.virtualBlockFinishL2Block &&
+            currentVirtualBlockUpgradeInfo.virtualBlockFinishL2Block > 0
+        ) {
             hash = _getLatest257L2blockHash(_block);
         } else {
-            // Important: we do not want this number to ever collide with the L2 block hash (either new or old one) and so 
-            // that's why the legacy L2 blocks' hashes are keccak256(abi.encodePacked(uint32(_block))), while these are equivalent to 
+            // Important: we do not want this number to ever collide with the L2 block hash (either new or old one) and so
+            // that's why the legacy L2 blocks' hashes are keccak256(abi.encodePacked(uint32(_block))), while these are equivalent to
             // keccak256(abi.encodePacked(_block))
             hash = keccak256(abi.encode(_block));
         }
@@ -151,7 +154,7 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
     }
 
     /// @notice Returns the current L2 block's number.
-    /// @dev Since zksolc compiler calls this method to emulate `block.number`, 
+    /// @dev Since zksolc compiler calls this method to emulate `block.number`,
     /// its signature can not be changed to `getL2BlockNumber`.
     /// @return blockNumber The current L2 block's number.
     function getBlockNumber() public view returns (uint128) {
@@ -159,7 +162,7 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
     }
 
     /// @notice Returns the current L2 block's timestamp.
-    /// @dev Since zksolc compiler calls this method to emulate `block.timestamp`, 
+    /// @dev Since zksolc compiler calls this method to emulate `block.timestamp`,
     /// its signature can not be changed to `getL2BlockTimestamp`.
     /// @return timestamp The current L2 block's timestamp.
     function getBlockTimestamp() public view returns (uint128) {
@@ -194,12 +197,10 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
         return keccak256(abi.encode(_blockNumber, _blockTimestamp, _prevL2BlockHash, _blockTxsRollingHash));
     }
 
-    /// @notice Calculates the legacy block hash of L2 block, which were used before the upgrade where 
+    /// @notice Calculates the legacy block hash of L2 block, which were used before the upgrade where
     /// the advanced block hashes were introduced.
     /// @param _blockNumber The number of the L2 block.
-    function _calculateLegacyL2BlockHash(
-        uint128 _blockNumber
-    ) internal pure returns (bytes32) {
+    function _calculateLegacyL2BlockHash(uint128 _blockNumber) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(uint32(_blockNumber)));
     }
 
@@ -207,21 +208,17 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
     /// @param _l2BlockNumber The number of the new L2 block.
     /// @param _expectedPrevL2BlockHash The expected hash of the previous L2 block.
     /// @param _isFirstInBatch Whether this method is called for the first time in the batch.
-    function _upgradeL2Blocks(
-        uint128 _l2BlockNumber, 
-        bytes32 _expectedPrevL2BlockHash,
-        bool _isFirstInBatch
-    ) internal {
+    function _upgradeL2Blocks(uint128 _l2BlockNumber, bytes32 _expectedPrevL2BlockHash, bool _isFirstInBatch) internal {
         require(_isFirstInBatch, "Upgrade transaction must be first");
-        
+
         // This is how it will be commonly done in practice, but it will simplify some logic later
         require(_l2BlockNumber > 0, "L2 block number is never expected to be zero");
-    
+
         unchecked {
             bytes32 correctPrevBlockHash = _calculateLegacyL2BlockHash(uint128(_l2BlockNumber - 1));
             require(correctPrevBlockHash == _expectedPrevL2BlockHash, "The previous L2 block hash is incorrect");
 
-            // Whenever we'll be queried about the hashes of the blocks before the upgrade, 
+            // Whenever we'll be queried about the hashes of the blocks before the upgrade,
             // we'll use batches' hashes, so we don't need to store 256 previous hashes.
             // However, we do need to store the last previous hash in order to be able to correctly calculate the
             // hash of the new L2 block.
@@ -238,11 +235,11 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
         uint128 _maxVirtualBlocksToCreate,
         uint128 _newTimestamp
     ) internal {
-        if(virtualBlockUpgradeInfo.virtualBlockFinishL2Block != 0) {
+        if (virtualBlockUpgradeInfo.virtualBlockFinishL2Block != 0) {
             // No need to to do anything about virtual blocks anymore
             // All the info is the same as for L2 blocks.
             currentVirtualL2BlockInfo = currentL2BlockInfo;
-            return; 
+            return;
         }
 
         BlockInfo memory virtualBlockInfo = currentVirtualL2BlockInfo;
@@ -251,7 +248,7 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
             uint128 currentBatchNumber = currentBatchInfo.number;
 
             // The virtual block is set for the first time. We can count it as 1 creation of a virtual block.
-            // Note, that when setting the virtual block number we use the batch number to make a smoother upgrade from batch number to 
+            // Note, that when setting the virtual block number we use the batch number to make a smoother upgrade from batch number to
             // the L2 block number.
             virtualBlockInfo.number = currentBatchNumber;
             // Remembering the batch number on which the upgrade to the virtual blocks has been done.
@@ -260,7 +257,7 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
             require(_maxVirtualBlocksToCreate > 0, "Can't initialize the first virtual block");
             _maxVirtualBlocksToCreate -= 1;
         } else if (_maxVirtualBlocksToCreate == 0) {
-            // The virtual blocks have been already initialized, but the operator didn't ask to create 
+            // The virtual blocks have been already initialized, but the operator didn't ask to create
             // any new virtual blocks. So we can just return.
             return;
         }
@@ -270,13 +267,13 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
 
         // The virtual block number must never exceed the L2 block number.
         // We do not use a `require` here, since the virtual blocks are a temporary solution to let the Solidity's `block.number`
-        // catch up with the L2 block number and so the situation where virtualBlockInfo.number starts getting larger 
+        // catch up with the L2 block number and so the situation where virtualBlockInfo.number starts getting larger
         // than _l2BlockNumber is expected once virtual blocks have caught up the L2 blocks.
         if (virtualBlockInfo.number >= _l2BlockNumber) {
             virtualBlockUpgradeInfo.virtualBlockFinishL2Block = _l2BlockNumber;
             virtualBlockInfo.number = _l2BlockNumber;
         }
-        
+
         currentVirtualL2BlockInfo = virtualBlockInfo;
     }
 
@@ -284,16 +281,9 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
     /// @param _l2BlockNumber The number of the new L2 block.
     /// @param _l2BlockTimestamp The timestamp of the new L2 block.
     /// @param _prevL2BlockHash The hash of the previous L2 block.
-    function _setNewL2BlockData(
-        uint128 _l2BlockNumber, 
-        uint128 _l2BlockTimestamp,
-        bytes32 _prevL2BlockHash
-    ) internal {
+    function _setNewL2BlockData(uint128 _l2BlockNumber, uint128 _l2BlockTimestamp, bytes32 _prevL2BlockHash) internal {
         // In the unsafe version we do not check that the block data is correct
-        currentL2BlockInfo = BlockInfo({
-            number: _l2BlockNumber,
-            timestamp: _l2BlockTimestamp
-        });
+        currentL2BlockInfo = BlockInfo({number: _l2BlockNumber, timestamp: _l2BlockTimestamp});
 
         // It is always assumed in production that _l2BlockNumber > 0
         _setL2BlockHash(_l2BlockNumber - 1, _prevL2BlockHash);
@@ -304,64 +294,69 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
 
     /// @notice Sets the current block number and timestamp of the L2 block.
     /// @dev Called by the bootloader before each transaction. This is needed to ensure
-    /// that the data about the block is consistent with the sequencer. 
-    /// @dev If the new block number is the same as the current one, we ensure that the block's data is 
+    /// that the data about the block is consistent with the sequencer.
+    /// @dev If the new block number is the same as the current one, we ensure that the block's data is
     /// consistent with the one in the current block.
-    /// @dev If the new block number is greater than the current one by 1, 
+    /// @dev If the new block number is greater than the current one by 1,
     /// then we ensure that timestamp has increased.
-    /// @dev If the currently stored number is 0, we assume that it is the first upgrade transaction 
+    /// @dev If the currently stored number is 0, we assume that it is the first upgrade transaction
     /// and so we will fill up the old data.
     /// @param _l2BlockNumber The number of the new L2 block.
     /// @param _l2BlockTimestamp The timestamp of the new L2 block.
     /// @param _expectedPrevL2BlockHash The expected hash of the previous L2 block.
     /// @param _isFirstInBatch Whether this method is called for the first time in the batch.
     /// @param _maxVirtualBlocksToCreate The maximum number of virtual block to create with this L2 block.
-    /// @dev It is a strict requirement that a new virtual block is created at the start of the batch. 
+    /// @dev It is a strict requirement that a new virtual block is created at the start of the batch.
     /// @dev It is also enforced that the number of the current virtual L2 block can not exceed the number of the L2 block.
     function setL2Block(
-        uint128 _l2BlockNumber, 
+        uint128 _l2BlockNumber,
         uint128 _l2BlockTimestamp,
         bytes32 _expectedPrevL2BlockHash,
         bool _isFirstInBatch,
         uint128 _maxVirtualBlocksToCreate
-    ) external onlyCallFromBootloader { 
+    ) external onlyCallFromBootloader {
         // We check that the timestamp of the L2 block is consistent with the timestamp of the batch.
-        if(_isFirstInBatch) {
+        if (_isFirstInBatch) {
             uint128 currentBatchTimestamp = currentBatchInfo.timestamp;
-            require(_l2BlockTimestamp >= currentBatchTimestamp, "The timestamp of the L2 block must be greater than or equal to the timestamp of the current batch");
+            require(
+                _l2BlockTimestamp >= currentBatchTimestamp,
+                "The timestamp of the L2 block must be greater than or equal to the timestamp of the current batch"
+            );
             require(_maxVirtualBlocksToCreate > 0, "There must be a virtual block created at the start of the batch");
         }
 
         (uint128 currentL2BlockNumber, uint128 currentL2BlockTimestamp) = getL2BlockNumberAndTimestamp();
 
         if (currentL2BlockNumber == 0 && currentL2BlockTimestamp == 0) {
-            // Since currentL2BlockNumber and currentL2BlockTimestamp are zero it means that it is 
+            // Since currentL2BlockNumber and currentL2BlockTimestamp are zero it means that it is
             // the first ever batch with L2 blocks, so we need to initialize those.
-            _upgradeL2Blocks(
-                _l2BlockNumber,
-                _expectedPrevL2BlockHash,
-                _isFirstInBatch
-            );
+            _upgradeL2Blocks(_l2BlockNumber, _expectedPrevL2BlockHash, _isFirstInBatch);
 
             _setNewL2BlockData(_l2BlockNumber, _l2BlockTimestamp, _expectedPrevL2BlockHash);
         } else if (currentL2BlockNumber == _l2BlockNumber) {
             require(!_isFirstInBatch, "Can not reuse L2 block number from the previous batch");
             require(currentL2BlockTimestamp == _l2BlockTimestamp, "The timestamp of the same L2 block must be same");
-            require(_expectedPrevL2BlockHash == _getLatest257L2blockHash(_l2BlockNumber - 1), "The previous hash of the same L2 block must be same");
+            require(
+                _expectedPrevL2BlockHash == _getLatest257L2blockHash(_l2BlockNumber - 1),
+                "The previous hash of the same L2 block must be same"
+            );
             require(_maxVirtualBlocksToCreate == 0, "Can not create virtual blocks in the middle of the miniblock");
         } else if (currentL2BlockNumber + 1 == _l2BlockNumber) {
             // From the checks in _upgradeL2Blocks it is known that currentL2BlockNumber can not be 0
             bytes32 prevL2BlockHash = _getLatest257L2blockHash(currentL2BlockNumber - 1);
 
             bytes32 pendingL2BlockHash = _calculateL2BlockHash(
-                currentL2BlockNumber, 
-                currentL2BlockTimestamp, 
-                prevL2BlockHash, 
+                currentL2BlockNumber,
+                currentL2BlockTimestamp,
+                prevL2BlockHash,
                 currentL2BlockTxsRollingHash
             );
 
             require(_expectedPrevL2BlockHash == pendingL2BlockHash, "The current L2 block hash is incorrect");
-            require(_l2BlockTimestamp > currentL2BlockTimestamp, "The timestamp of the new L2 block must be greater than the timestamp of the previous L2 block");
+            require(
+                _l2BlockTimestamp > currentL2BlockTimestamp,
+                "The timestamp of the new L2 block must be greater than the timestamp of the previous L2 block"
+            );
 
             // Since the new block is created, we'll clear out the rolling hash
             _setNewL2BlockData(_l2BlockNumber, _l2BlockTimestamp, _expectedPrevL2BlockHash);
@@ -374,9 +369,7 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
 
     /// @notice Appends the transaction hash to the rolling hash of the current L2 block.
     /// @param _txHash The hash of the transaction.
-    function appendTransactionToCurrentL2Block(
-        bytes32 _txHash
-    ) external onlyCallFromBootloader {
+    function appendTransactionToCurrentL2Block(bytes32 _txHash) external onlyCallFromBootloader {
         currentL2BlockTxsRollingHash = keccak256(abi.encode(currentL2BlockTxsRollingHash, _txHash));
     }
 
@@ -393,16 +386,21 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
         // In order to spend less pubdata, the packed version is published
         uint256 packedTimestamps = (uint256(currentBatchTimestamp) << 128) | currentL2BlockTimestamp;
 
-        SystemContractHelper.toL1(false, bytes32(uint256(SystemLogKey.PACKED_BATCH_AND_L2_BLOCK_TIMESTAMP_KEY)), bytes32(packedTimestamps));
+        SystemContractHelper.toL1(
+            false,
+            bytes32(uint256(SystemLogKey.PACKED_BATCH_AND_L2_BLOCK_TIMESTAMP_KEY)),
+            bytes32(packedTimestamps)
+        );
     }
 
     /// @notice Ensures that the timestamp of the batch is greater than the timestamp of the last L2 block.
     /// @param _newTimestamp The timestamp of the new batch.
-    function _ensureBatchConsistentWithL2Block(
-        uint128 _newTimestamp
-    ) internal view {
+    function _ensureBatchConsistentWithL2Block(uint128 _newTimestamp) internal view {
         uint128 currentBlockTimestamp = currentL2BlockInfo.timestamp;
-        require(_newTimestamp > currentBlockTimestamp, "The timestamp of the batch must be greater than the timestamp of the previous block");
+        require(
+            _newTimestamp > currentBlockTimestamp,
+            "The timestamp of the batch must be greater than the timestamp of the previous block"
+        );
     }
 
     /// @notice Increments the current batch number and sets the new timestamp
@@ -423,16 +421,13 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
         (uint128 previousBatchNumber, uint128 previousBatchTimestamp) = getBatchNumberAndTimestamp();
         require(_newTimestamp > previousBatchTimestamp, "Timestamps should be incremental");
         require(previousBatchNumber + 1 == _expectedNewNumber, "The provided block number is not correct");
-        
+
         _ensureBatchConsistentWithL2Block(_newTimestamp);
 
         batchHash[previousBatchNumber] = _prevBatchHash;
 
         // Setting new block number and timestamp
-        BlockInfo memory newBlockInfo = BlockInfo({
-            number: previousBatchNumber + 1,
-            timestamp: _newTimestamp
-        });
+        BlockInfo memory newBlockInfo = BlockInfo({number: previousBatchNumber + 1, timestamp: _newTimestamp});
 
         currentBatchInfo = newBlockInfo;
 
@@ -444,11 +439,12 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
 
     /// @notice A testing method that manually sets the current blocks' number and timestamp.
     /// @dev Should be used only for testing / ethCalls and should never be used in production.
-    function unsafeOverrideBatch(uint256 _newTimestamp, uint256 _number, uint256 _baseFee) external onlyCallFromBootloader {
-        BlockInfo memory newBlockInfo = BlockInfo({
-            number: uint128(_number),
-            timestamp: uint128(_newTimestamp)
-        });
+    function unsafeOverrideBatch(
+        uint256 _newTimestamp,
+        uint256 _number,
+        uint256 _baseFee
+    ) external onlyCallFromBootloader {
+        BlockInfo memory newBlockInfo = BlockInfo({number: uint128(_number), timestamp: uint128(_newTimestamp)});
         currentBatchInfo = newBlockInfo;
 
         baseFee = _baseFee;
@@ -467,20 +463,20 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Returns the current batch's number and timestamp.
-    /// @dev Deprecated in favor of getBatchNumberAndTimestamp. 
+    /// @dev Deprecated in favor of getBatchNumberAndTimestamp.
     function currentBlockInfo() external view returns (uint256 blockInfo) {
         (uint128 blockNumber, uint128 blockTimestamp) = getBatchNumberAndTimestamp();
-        blockInfo = uint256(blockNumber) << 128 | uint256(blockTimestamp);
+        blockInfo = (uint256(blockNumber) << 128) | uint256(blockTimestamp);
     }
-    
+
     /// @notice Returns the current batch's number and timestamp.
-    /// @dev Deprecated in favor of getBatchNumberAndTimestamp. 
+    /// @dev Deprecated in favor of getBatchNumberAndTimestamp.
     function getBlockNumberAndTimestamp() external view returns (uint256 blockNumber, uint256 blockTimestamp) {
         (blockNumber, blockTimestamp) = getBatchNumberAndTimestamp();
     }
 
     /// @notice Returns the hash of the given batch.
-    /// @dev Deprecated in favor of getBatchHash. 
+    /// @dev Deprecated in favor of getBatchHash.
     function blockHash(uint256 _blockNumber) external view returns (bytes32 hash) {
         hash = batchHash[_blockNumber];
     }

--- a/contracts/interfaces/ICompressor.sol
+++ b/contracts/interfaces/ICompressor.sol
@@ -2,11 +2,11 @@
 
 pragma solidity ^0.8.0;
 
-/// @notice The bitmask by applying which to the compressed state diff metadata we retrieve its operation.
+// The bitmask by applying which to the compressed state diff metadata we retrieve its operation.
 uint8 constant OPERATION_BITMASK = 7;
-/// @notice The number of bits shifting the compressed state diff metadata by which we retrieve its length.
+// The number of bits shifting the compressed state diff metadata by which we retrieve its length.
 uint8 constant LENGTH_BITS_OFFSET = 3;
-/// @notice The maximal length in bytes that an enumeration index can have.
+// The maximal length in bytes that an enumeration index can have.
 uint8 constant MAX_ENUMERATION_INDEX_SIZE = 8;
 
 interface ICompressor {

--- a/contracts/interfaces/ICompressor.sol
+++ b/contracts/interfaces/ICompressor.sol
@@ -2,6 +2,10 @@
 
 pragma solidity ^0.8.0;
 
+uint8 constant OPERATION_BITMASK = 7;
+
+uint8 constant LENGTH_BITS_OFFSET = 3;
+
 interface ICompressor {
     function publishCompressedBytecode(
         bytes calldata _bytecode,
@@ -10,6 +14,7 @@ interface ICompressor {
 
     function verifyCompressedStateDiffs(
         uint256 _numberOfStateDiffs,
+        uint256 _enumerationIndexSize,
         bytes calldata _stateDiffs,
         bytes calldata _compressedStateDiffs
     ) external payable returns (bytes32 stateDiffHash);

--- a/contracts/interfaces/ICompressor.sol
+++ b/contracts/interfaces/ICompressor.sol
@@ -2,9 +2,12 @@
 
 pragma solidity ^0.8.0;
 
+/// @notice The bitmask by applying which to the compressed state diff metadata we retrieve its operation.
 uint8 constant OPERATION_BITMASK = 7;
-
+/// @notice The number of bits shifting the compressed state diff metadata by which we retrieve its length.
 uint8 constant LENGTH_BITS_OFFSET = 3;
+/// @notice The maximal length in bytes that an enumeration index can have.
+uint8 constant MAX_ENUMERATION_INDEX_SIZE = 8;
 
 interface ICompressor {
     function publishCompressedBytecode(

--- a/contracts/interfaces/IL1Messenger.sol
+++ b/contracts/interfaces/IL1Messenger.sol
@@ -29,6 +29,9 @@ uint256 constant L2_TO_L1_LOG_SERIALIZE_SIZE = 88;
 /// @dev Actually equal to the `keccak256(new bytes(L2_TO_L1_LOG_SERIALIZE_SIZE))`
 bytes32 constant L2_L1_LOGS_TREE_DEFAULT_LEAF_HASH = 0x72abee45b59e344af8a6e520241c4744aff26ed411f4c4b00f8af09adada43ba;
 
+/// @dev The current version of state diff compression being used.
+uint256 constant STATE_DIFF_COMPRESSION_VERSION_NUMBER = 1;
+
 interface IL1Messenger {
     // Possibly in the future we will be able to track the messages sent to L1 with
     // some hooks in the VM. For now, it is much easier to track them with L2 events.

--- a/contracts/interfaces/ISystemContext.sol
+++ b/contracts/interfaces/ISystemContext.sol
@@ -16,11 +16,10 @@ interface ISystemContext {
     /// @notice A structure representing the timeline for the upgrade from the batch numbers to the L2 block numbers.
     /// @dev It will used for the L1 batch -> L2 block migration in Q3 2023 only.
     struct VirtualBlockUpgradeInfo {
-        /// @notice In order to maintain consistent results for `blockhash` requests, we'll 
+        /// @notice In order to maintain consistent results for `blockhash` requests, we'll
         /// have to remember the number of the batch when the upgrade to the virtual blocks has been done.
         /// The hashes for virtual blocks before the upgrade are identical to the hashes of the corresponding batches.
         uint128 virtualBlockStartBatch;
-
         /// @notice L2 block when the virtual blocks have caught up with the L2 blocks. Starting from this block,
         /// all the information returned to users for block.timestamp/number, etc should be the information about the L2 blocks and
         /// not virtual blocks.

--- a/contracts/interfaces/ISystemContextDeprecated.sol
+++ b/contracts/interfaces/ISystemContextDeprecated.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.0;
  * @notice The interface with deprecated functions of the SystemContext contract. It is aimed for backward compatibility.
  */
 interface ISystemContextDeprecated {
-    function currentBlockInfo() external view returns(uint256);
+    function currentBlockInfo() external view returns (uint256);
 
     function getBlockNumberAndTimestamp() external view returns (uint256 blockNumber, uint256 blockTimestamp);
 

--- a/contracts/libraries/UnsafeBytesCalldata.sol
+++ b/contracts/libraries/UnsafeBytesCalldata.sol
@@ -41,4 +41,10 @@ library UnsafeBytesCalldata {
             result := calldataload(add(_bytes.offset, _start))
         }
     }
+
+    function readUint256(bytes calldata _bytes, uint256 _start) internal pure returns (uint256 result) {
+        assembly {
+            result := calldataload(add(_bytes.offset, _start))
+        }
+    }
 }


### PR DESCRIPTION
# What ❔
Edit the compression algorithm used for state diffs. The prior one was used to make sure the system worked with the old format but this upgrade will allow us to have ~70% gain in data compression.

<!-- What are the changes this PR brings about? -->
Change how state diffs are processed at the end of the batch.
- `L1Messenger` is updated to parse out the new format/values
- `Compressor` is updated to properly compare the encoded state diffs vs the new compressed state diffs

## Why ❔
While the current iteration of compression works, we can achieve further compression with this new algorithm bringing down the amount of data needed and thus costs due to pubdata publishing.

## Checklist

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
