### PR TITLE
Fix _maxRefundedGas provided to the paymaster

### DIFF
--- a/bootloader/bootloader.yul
+++ b/bootloader/bootloader.yul
@@ -1466,7 +1466,9 @@ object "Bootloader" {
                             paymaster,
                             txDataOffset,
                             success,
-                            gasLeft
+                            // Since the paymaster will be refunded with reservedGas,
+                            // it should know about it
+                            add(gasLeft, reservedGas),
                         ))
                         let gasSpentByPostOp := sub(gasBeforePostOp, gas())
 

--- a/bootloader/bootloader.yul
+++ b/bootloader/bootloader.yul
@@ -1468,7 +1468,7 @@ object "Bootloader" {
                             success,
                             // Since the paymaster will be refunded with reservedGas,
                             // it should know about it
-                            add(gasLeft, reservedGas),
+                            safeAdd(gasLeft, reservedGas),
                         ))
                         let gasSpentByPostOp := sub(gasBeforePostOp, gas())
 


### PR DESCRIPTION
# What ❔

This PR ensures that the paymaster receives both the execution gas left and the gas left from the pubdata for the `postTransaction` method.

## Why ❔

Before, the paymaster received `gasLeft` as maxRefundedGas, which was roughly equal to the gas provided to the paymaster during the postOp call, however a lot more gas would be actually refunded to it.


## Checklist

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
