### PR TITLE
Enforce paymasterInput to be empty when the paymaster is 0

### DIFF
--- a/bootloader/bootloader.yul
+++ b/bootloader/bootloader.yul
@@ -2947,6 +2947,12 @@ object "Bootloader" {
                     case 113 {                        
                         let paymaster := getPaymaster(innerTxDataOffset)
                         assertEq(or(gt(paymaster, MAX_SYSTEM_CONTRACT_ADDR()), iszero(paymaster)), 1, "paymaster in kernel space")
+
+                        if iszero(paymaster) {
+                            // Double checking that the paymasterInput is 0 if the paymaster is 0
+                            assertEq(getPaymasterInputBytesLength(innerTxDataOffset), 0, "paymasterInput non zero")
+                        }
+
                         <!-- @if BOOTLOADER_TYPE=='proved_batch' -->
                         assertEq(gt(getFrom(innerTxDataOffset), MAX_SYSTEM_CONTRACT_ADDR()), 1, "from in kernel space")
                         <!-- @endif -->


### PR DESCRIPTION
# What ❔

Enforce `paymasterInput` to be empty when the paymaster is `0`

## Why ❔

Allowing non empty `paymasterInput` when the paymaster is 0 (i.e. the paymaster will not be used) is error-prone 

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
