### PR TITLE
Use padded state diffs

### DIFF
--- a/contracts/Constants.sol
+++ b/contracts/Constants.sol
@@ -77,7 +77,8 @@ bytes32 constant CREATE2_PREFIX = 0x2020dba91b30cc0006188af794c2fb30dd8520db7e2c
 /// @dev keccak256("zksyncCreate")
 bytes32 constant CREATE_PREFIX = 0x63bae3a9951d38e8a3fbb7b70909afc1200610fc5bc55ade242f815974674f23;
 
-uint256 constant STATE_DIFF_ENTRY_SIZE = 156;
+/// @dev Each state diffs consists of 156 bytes of actual data and 116 bytes of unused padding.
+uint256 constant STATE_DIFF_ENTRY_SIZE = 272;
 
 /// @dev While the "real" amount of pubdata that can be sent rarely exceeds the 110k - 120k, it is better to 
 /// allow the operator to provide any reasonably large value in order to avoid unneeded constraints on the operator.  

--- a/contracts/Constants.sol
+++ b/contracts/Constants.sol
@@ -77,7 +77,7 @@ bytes32 constant CREATE2_PREFIX = 0x2020dba91b30cc0006188af794c2fb30dd8520db7e2c
 /// @dev keccak256("zksyncCreate")
 bytes32 constant CREATE_PREFIX = 0x63bae3a9951d38e8a3fbb7b70909afc1200610fc5bc55ade242f815974674f23;
 
-/// @dev Each state diffs consists of 156 bytes of actual data and 116 bytes of unused padding.
+/// @dev Each state diff consists of 156 bytes of actual data and 116 bytes of unused padding, needed for circuit efficiency.
 uint256 constant STATE_DIFF_ENTRY_SIZE = 272;
 
 /// @dev While the "real" amount of pubdata that can be sent rarely exceeds the 110k - 120k, it is better to 


### PR DESCRIPTION
# What ❔

Make sure that the original state diffs are padded to be equal to the same value as in circuits.

## Why ❔

The commitment to the full state diffs is used as public input in ZKP.

## Checklist

- [+] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [+] Tests for the changes have been added / updated.
- [+] Documentation comments have been added / updated.
- [+] Code has been formatted via `zk fmt` and `zk lint`.
