### PR TITLE
ci: use era-test-node-action for the testing CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Use era-test-node for testing
         uses: dutterbutter/era-test-node-action@latest
         with:
-          releaseTag: "v0.0.1-alpha.boojum"
+          releaseTag: tags/v0.0.1-alpha.boojum
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,17 +105,8 @@ jobs:
           node-version: 18.18.0
           cache: yarn
 
-      - name: Use Nightly Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: nightly-2023-04-17
-
-      - name: Use era_test_node for testing
-        uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
-        with:
-          crate: era_test_node
-          git: https://github.com/matter-labs/era-test-node.git
-          branch: boojum-integration
+      - name: Use era-test-node for testing
+        uses: dutterbutter/era-test-node-action@latest
 
       - name: Install dependencies
         run: yarn
@@ -132,9 +123,6 @@ jobs:
             contracts/artifacts
             contracts/precompiles/artifacts
             bootloader/build
-
-      - name: Start era_test_node
-        run: era_test_node run > /dev/null 2>&1 &
 
       - name: Run tests
         run: yarn test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,9 +106,9 @@ jobs:
           cache: yarn
 
       - name: Use era-test-node for testing
-        uses: dutterbutter/era-test-node-action@latest
+        uses: dutterbutter/era-test-node-action@v0.1.3
         with:
-          releaseTag: tags/v0.0.1-alpha.boojum
+          releaseTag: v0.0.1-alpha.boojum
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,6 +107,8 @@ jobs:
 
       - name: Use era-test-node for testing
         uses: dutterbutter/era-test-node-action@latest
+        with:
+          releaseTag: v0.0.1-alpha.boojum
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Use era-test-node for testing
         uses: dutterbutter/era-test-node-action@latest
         with:
-          releaseTag: v0.0.1-alpha.boojum
+          releaseTag: "v0.0.1-alpha.boojum"
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
# What ❔
Use the boojum release's pre-built binary of the [era-test-node](https://github.com/matter-labs/era-test-node), instead of building it from source in the CI.

Steps:
1. use the [era-test-node-action](https://github.com/dutterbutter/era-test-node-action) in the CI testing instead of manually checking out the branch
2. set the releaseTag to boojum to use the boojum release

## Why ❔
The current testing CI builds the binary from source, this was just a temporarily solution until an official release of the test node, now that we have the release, use that instead.

## Checklist
- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] ~Tests for the changes have been added / updated.~
- [ ] ~Documentation comments have been added / updated.~
- [x] Code has been formatted via `yarn prettier:write` and `yarn lint:fix`.
