### PR TITLE
updated hh version and solidity version

### DIFF
--- a/SystemContractsHashes.json
+++ b/SystemContractsHashes.json
@@ -3,42 +3,42 @@
     "contractName": "AccountCodeStorage",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/AccountCodeStorage.sol/AccountCodeStorage.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/AccountCodeStorage.sol",
-    "bytecodeHash": "0x0100007516973f1ad37fd05bcc2f86101909a85c565e2e0862e9a69d6996d176",
+    "bytecodeHash": "0x010000750bdca11eebd5ebf32a4198e0737296cd794503dcbc6fc28ce7952cf3",
     "sourceCodeHash": "0xb7a285eceef853b5259266de51584c7120fdc0335657b457c63a331301c96d8f"
   },
   {
     "contractName": "BootloaderUtilities",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/BootloaderUtilities.sol/BootloaderUtilities.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/BootloaderUtilities.sol",
-    "bytecodeHash": "0x010007dd45596adcedb61dbb9f68569b8e65bfd0a748655cef0805a686363311",
+    "bytecodeHash": "0x010007ddff9f0bf55496a0f30386455f2dfb74699d93f3e255570479028ed86f",
     "sourceCodeHash": "0xf40ae3c82f6eb7b88e4d926c706c3edc3c2ce07bb60f60cd21accd228f38c212"
   },
   {
     "contractName": "ComplexUpgrader",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/ComplexUpgrader.sol/ComplexUpgrader.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/ComplexUpgrader.sol",
-    "bytecodeHash": "0x010000559a8038d9ebf9cb91abb48345f8ec67395617c0614787a298181bf8ba",
+    "bytecodeHash": "0x010000552d5024a96fe1620ecf6cf9b84a9d2e2e150ca98e487b94e42ffc527d",
     "sourceCodeHash": "0xbf583b121fde4d406912afa7af7943adb440e355fcbf476f5b454c58fd07eda0"
   },
   {
     "contractName": "Compressor",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/Compressor.sol/Compressor.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/Compressor.sol",
-    "bytecodeHash": "0x01000167e557f0f5b6fd5c7543d7b5e3398070ded2f1cfdf9bf00b82f3a60395",
+    "bytecodeHash": "0x010001671c13f9a1f43f05fb67ee8b0ba39d8fd39764ad9928f4a1191be7aec5",
     "sourceCodeHash": "0xba41d1e46cd62c08f61ac78b693e5adbb5428f33640e0e55ff58cbd04093cd07"
   },
   {
     "contractName": "ContractDeployer",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/ContractDeployer.sol/ContractDeployer.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/ContractDeployer.sol",
-    "bytecodeHash": "0x0100051bbd5dfd67950e195d6605d235a52bd9bb3723a8f34c47993609c0e164",
+    "bytecodeHash": "0x0100051b09a26fb09d4c600fc1320b9407dfc22f3e9c91f5656fc20694b39714",
     "sourceCodeHash": "0x99e484499462d7caea209e8386bd09dad1387c60d5034f3acdccc7b271b1c764"
   },
   {
     "contractName": "DefaultAccount",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/DefaultAccount.sol/DefaultAccount.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/DefaultAccount.sol",
-    "bytecodeHash": "0x0100055bf820db07101286892a8f28aa4744005cfe66e716cd91747acce1cb71",
+    "bytecodeHash": "0x0100055bca2a769a5d9bb32a3d6369cd9f6b38ec69a5e4a2b64fd686745bd3a3",
     "sourceCodeHash": "0xb30019238c2b8574e2a87960f4eed241548c0599c0eb5a6420d1d24d63377210"
   },
   {
@@ -52,49 +52,49 @@
     "contractName": "ImmutableSimulator",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/ImmutableSimulator.sol/ImmutableSimulator.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/ImmutableSimulator.sol",
-    "bytecodeHash": "0x0100003ffeda445065d1af6cafb152d1b90f6f4eec8e9af393bd73cffb8d59eb",
+    "bytecodeHash": "0x0100003f4ed73dd4425144beaf0f49049016f3abed132709d588c8960c9d6f49",
     "sourceCodeHash": "0x8d1f252875fe4a8a1cd51bf7bd678b9bff7542bb468f75929cea69df4a16850d"
   },
   {
     "contractName": "KnownCodesStorage",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/KnownCodesStorage.sol/KnownCodesStorage.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/KnownCodesStorage.sol",
-    "bytecodeHash": "0x0100007d8202b8943737d03bebe18464b6fd8c473c7aeeff0bb49e58e408e138",
+    "bytecodeHash": "0x0100007d4953bd4d0ad560157bc725d418e36622d739560470cdccb261fa8702",
     "sourceCodeHash": "0x15cb53060dad4c62e72c62777ff6a25029c6ec0ab37adacb684d0e275cec6749"
   },
   {
     "contractName": "L1Messenger",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/L1Messenger.sol/L1Messenger.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/L1Messenger.sol",
-    "bytecodeHash": "0x01000289b678909f8a11d0e6df9c21f91603ff1fdcfbb4919ad2d9196b2cf2ec",
+    "bytecodeHash": "0x01000289e84ffaafdf8cc5561b83a1a73bf40b46814bf4aa257433fabdf0db16",
     "sourceCodeHash": "0x3dce2fc308f7d911a2d80460b895322f954f43ed6bca1893f34ae3469c05b222"
   },
   {
     "contractName": "L2EthToken",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/L2EthToken.sol/L2EthToken.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/L2EthToken.sol",
-    "bytecodeHash": "0x0100010331035309eaed8e5c8ee8e7e72260ca24badf42bc916a7e0a7826a9cb",
+    "bytecodeHash": "0x010001035ec28616cfd76956cb398570c2fd0e233fb354937010c6cfb8c4d2c8",
     "sourceCodeHash": "0xadc69be5b5799d0f1a6fa71d56a6706b146447c8e3c6516a5191a0b23bd134e8"
   },
   {
     "contractName": "MsgValueSimulator",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/MsgValueSimulator.sol/MsgValueSimulator.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/MsgValueSimulator.sol",
-    "bytecodeHash": "0x01000063875cce9ea833c97442d2f83db53fce6ff0ea73bc1945757eef19b908",
+    "bytecodeHash": "0x01000063843d7506f9464a1ecc8d6723d8bf84ea704c2e6bafc638ee4ff56935",
     "sourceCodeHash": "0xe7a85dc51512cab431d12bf062847c4dcf2f1c867e7d547ff95638f6a4e8fd4e"
   },
   {
     "contractName": "NonceHolder",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/NonceHolder.sol/NonceHolder.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/NonceHolder.sol",
-    "bytecodeHash": "0x010000e5cc02451d85f48498359034c9d4926aec7219e60803d832f490d7be53",
+    "bytecodeHash": "0x010000e56f86bf10bf1275aefedc6c0bdc7b31948c41402d66aba06b48b9fca0",
     "sourceCodeHash": "0x04da0e5560c6cca2d0d5c965ee67d4cae9273367b77afef106108d4e8a2624b5"
   },
   {
     "contractName": "SystemContext",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/SystemContext.sol/SystemContext.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/SystemContext.sol",
-    "bytecodeHash": "0x010001894fd125f294f86904dfb4358e81f1d7a6f83807994c3f029872f072d5",
+    "bytecodeHash": "0x010001895b7b3163f87585bc1692536886f10de4923e99d22d150a35eb16dda9",
     "sourceCodeHash": "0x422768c771c4e4c077b66b9c4dd36e6dbeda4da058698ece239a0ad95b316646"
   },
   {

--- a/SystemContractsHashes.json
+++ b/SystemContractsHashes.json
@@ -3,175 +3,175 @@
     "contractName": "AccountCodeStorage",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/AccountCodeStorage.sol/AccountCodeStorage.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/AccountCodeStorage.sol",
-    "bytecodeHash": "0x010000750bdca11eebd5ebf32a4198e0737296cd794503dcbc6fc28ce7952cf3",
+    "bytecodeHash": "0x0100009b175ab666eac6aebd5540b5d97d0b867e58dfd78ac28b326841475aee",
     "sourceCodeHash": "0xb7a285eceef853b5259266de51584c7120fdc0335657b457c63a331301c96d8f"
   },
   {
     "contractName": "BootloaderUtilities",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/BootloaderUtilities.sol/BootloaderUtilities.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/BootloaderUtilities.sol",
-    "bytecodeHash": "0x010007ddff9f0bf55496a0f30386455f2dfb74699d93f3e255570479028ed86f",
+    "bytecodeHash": "0x010009754240bc8ff438f892d6e90695fae5a45895750b185ca45d1d7148498e",
     "sourceCodeHash": "0xf40ae3c82f6eb7b88e4d926c706c3edc3c2ce07bb60f60cd21accd228f38c212"
   },
   {
     "contractName": "ComplexUpgrader",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/ComplexUpgrader.sol/ComplexUpgrader.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/ComplexUpgrader.sol",
-    "bytecodeHash": "0x010000552d5024a96fe1620ecf6cf9b84a9d2e2e150ca98e487b94e42ffc527d",
+    "bytecodeHash": "0x0100005b2459f497f705e6956088748d082cd19aead231f82baaa441fb41d518",
     "sourceCodeHash": "0xbf583b121fde4d406912afa7af7943adb440e355fcbf476f5b454c58fd07eda0"
   },
   {
     "contractName": "Compressor",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/Compressor.sol/Compressor.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/Compressor.sol",
-    "bytecodeHash": "0x010001671c13f9a1f43f05fb67ee8b0ba39d8fd39764ad9928f4a1191be7aec5",
+    "bytecodeHash": "0x010001b7f55ea4f3ce8fa1c6a8a483f7773d54397b4c52a5f159485562ba37bd",
     "sourceCodeHash": "0xba41d1e46cd62c08f61ac78b693e5adbb5428f33640e0e55ff58cbd04093cd07"
   },
   {
     "contractName": "ContractDeployer",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/ContractDeployer.sol/ContractDeployer.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/ContractDeployer.sol",
-    "bytecodeHash": "0x0100051b09a26fb09d4c600fc1320b9407dfc22f3e9c91f5656fc20694b39714",
+    "bytecodeHash": "0x010005bbbdd733760a538d99b6a9569c9abbbb03e1687ef71fdf09ffbef76aaf",
     "sourceCodeHash": "0x99e484499462d7caea209e8386bd09dad1387c60d5034f3acdccc7b271b1c764"
   },
   {
     "contractName": "DefaultAccount",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/DefaultAccount.sol/DefaultAccount.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/DefaultAccount.sol",
-    "bytecodeHash": "0x0100055bca2a769a5d9bb32a3d6369cd9f6b38ec69a5e4a2b64fd686745bd3a3",
+    "bytecodeHash": "0x0100065dd78052e25d9a27d81f1ff52c11ee1bffd85998f8a339b419ff3a3a1a",
     "sourceCodeHash": "0xb30019238c2b8574e2a87960f4eed241548c0599c0eb5a6420d1d24d63377210"
   },
   {
     "contractName": "EmptyContract",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/EmptyContract.sol/EmptyContract.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/EmptyContract.sol",
-    "bytecodeHash": "0x0100000755a7b3a125cc9d9124000baae5e5a0644e7605d167e6f88ce89ec855",
+    "bytecodeHash": "0x01000007271e9710c356751295d83a25ffec94be2b4ada01ec1fa04c7cd6f2c7",
     "sourceCodeHash": "0x8bb626635c3cab6c5fc3b83e2ce09f98a8193ecdf019653bbe55d6cae3138b5d"
   },
   {
     "contractName": "ImmutableSimulator",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/ImmutableSimulator.sol/ImmutableSimulator.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/ImmutableSimulator.sol",
-    "bytecodeHash": "0x0100003f4ed73dd4425144beaf0f49049016f3abed132709d588c8960c9d6f49",
+    "bytecodeHash": "0x010000475e421f56cf54cdbf60997ed12aad55cc9e0b8e3b84ed43a27c1a6d9d",
     "sourceCodeHash": "0x8d1f252875fe4a8a1cd51bf7bd678b9bff7542bb468f75929cea69df4a16850d"
   },
   {
     "contractName": "KnownCodesStorage",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/KnownCodesStorage.sol/KnownCodesStorage.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/KnownCodesStorage.sol",
-    "bytecodeHash": "0x0100007d4953bd4d0ad560157bc725d418e36622d739560470cdccb261fa8702",
+    "bytecodeHash": "0x0100008b5f445f1769b9914d9e58f324cb5908b33ea2dd91584dc1919aa8431f",
     "sourceCodeHash": "0x15cb53060dad4c62e72c62777ff6a25029c6ec0ab37adacb684d0e275cec6749"
   },
   {
     "contractName": "L1Messenger",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/L1Messenger.sol/L1Messenger.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/L1Messenger.sol",
-    "bytecodeHash": "0x01000289e84ffaafdf8cc5561b83a1a73bf40b46814bf4aa257433fabdf0db16",
+    "bytecodeHash": "0x010002fbc517590966080d4440c139e35b8a411f503cac206163c0256c3aa5bf",
     "sourceCodeHash": "0x3dce2fc308f7d911a2d80460b895322f954f43ed6bca1893f34ae3469c05b222"
   },
   {
     "contractName": "L2EthToken",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/L2EthToken.sol/L2EthToken.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/L2EthToken.sol",
-    "bytecodeHash": "0x010001035ec28616cfd76956cb398570c2fd0e233fb354937010c6cfb8c4d2c8",
+    "bytecodeHash": "0x01000139335e820a31a7dd9706d29589db9cd0dc5ba9efd0ff3d303a853064a1",
     "sourceCodeHash": "0xadc69be5b5799d0f1a6fa71d56a6706b146447c8e3c6516a5191a0b23bd134e8"
   },
   {
     "contractName": "MsgValueSimulator",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/MsgValueSimulator.sol/MsgValueSimulator.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/MsgValueSimulator.sol",
-    "bytecodeHash": "0x01000063843d7506f9464a1ecc8d6723d8bf84ea704c2e6bafc638ee4ff56935",
+    "bytecodeHash": "0x0100006f336d39b95b20fb01e9661bf8145beff9e3bd5e97d1fa96ccaf8f7307",
     "sourceCodeHash": "0xe7a85dc51512cab431d12bf062847c4dcf2f1c867e7d547ff95638f6a4e8fd4e"
   },
   {
     "contractName": "NonceHolder",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/NonceHolder.sol/NonceHolder.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/NonceHolder.sol",
-    "bytecodeHash": "0x010000e56f86bf10bf1275aefedc6c0bdc7b31948c41402d66aba06b48b9fca0",
+    "bytecodeHash": "0x0100012f7ffee4eb58ec639a3269a35bc5065a24f5221c2d5993bf6b69b7d3c3",
     "sourceCodeHash": "0x04da0e5560c6cca2d0d5c965ee67d4cae9273367b77afef106108d4e8a2624b5"
   },
   {
     "contractName": "SystemContext",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/SystemContext.sol/SystemContext.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/SystemContext.sol",
-    "bytecodeHash": "0x010001895b7b3163f87585bc1692536886f10de4923e99d22d150a35eb16dda9",
+    "bytecodeHash": "0x0100023f2225bb3fc545271d5020934b26396f6c66256229ae286f4372ca3116",
     "sourceCodeHash": "0x422768c771c4e4c077b66b9c4dd36e6dbeda4da058698ece239a0ad95b316646"
   },
   {
     "contractName": "EventWriter",
     "bytecodePath": "contracts/artifacts/EventWriter.yul/EventWriter.yul.zbin",
     "sourceCodePath": "contracts/EventWriter.yul",
-    "bytecodeHash": "0x0100001704e8d1d46fcfd6da6e0c7c908b3044a0ef1cb1c2dd1017e319eedc85",
+    "bytecodeHash": "0x01000019642d87621fdd82cf65aa9146486c9256d5f8849af9a37c78ef519339",
     "sourceCodeHash": "0x55cfee65f174350edfd690c949bc0a29458f25da11f1d5f90b57621567df1fc3"
   },
   {
     "contractName": "EcAdd",
     "bytecodePath": "contracts/precompiles/artifacts/EcAdd.yul/EcAdd.yul.zbin",
     "sourceCodePath": "contracts/precompiles/EcAdd.yul",
-    "bytecodeHash": "0x010000c122358451b5dbb05598367816e79f73ad84493314683b085c0b2de491",
+    "bytecodeHash": "0x010000c56c054a0de4a36b133d3c114ec514c3ce0334ad7759c202392386a913",
     "sourceCodeHash": "0xe73c8960a8b4060113adca9f03207d379580d172df9f0b499dd5353934a557a6"
   },
   {
     "contractName": "EcMul",
     "bytecodePath": "contracts/precompiles/artifacts/EcMul.yul/EcMul.yul.zbin",
     "sourceCodePath": "contracts/precompiles/EcMul.yul",
-    "bytecodeHash": "0x0100012bb789c1c70f50bafa5b92e5b987495ed53695cecfbe4444583b50372c",
+    "bytecodeHash": "0x010001378d31273c8e58caa12bcf1a5694e66a0aefdba2504adb8e3eb02b21c7",
     "sourceCodeHash": "0x6c4b11542bcf85e6e02ca193fc0548353b1f21c27e972b9e73781e8f7eaf50b0"
   },
   {
     "contractName": "Ecrecover",
     "bytecodePath": "contracts/precompiles/artifacts/Ecrecover.yul/Ecrecover.yul.zbin",
     "sourceCodePath": "contracts/precompiles/Ecrecover.yul",
-    "bytecodeHash": "0x01000011f73843169ea4bd062afd909ea3b7b04efe4b1e69fb8d3a83d01f4ad4",
+    "bytecodeHash": "0x010000114daca2ff44f27d543b8ef67d885bfed09a74ba9cb25f5912dd3d739c",
     "sourceCodeHash": "0x18eac0a993afec4112da99fc8e2978891598ab12566528628896f430c855fb81"
   },
   {
     "contractName": "Keccak256",
     "bytecodePath": "contracts/precompiles/artifacts/Keccak256.yul/Keccak256.yul.zbin",
     "sourceCodePath": "contracts/precompiles/Keccak256.yul",
-    "bytecodeHash": "0x0100001f09b3d2e8a832b0a7f27fa2bf41594a286b0e7601503d3cb1918d165c",
+    "bytecodeHash": "0x0100001fb52ca33668d01c230a1c3b13ede90fe2e37d77222410e9f183cb7a89",
     "sourceCodeHash": "0x6415e127a4e07907fb87d0cbdf480fff8c70326c4f2f670af0cf3248862e4df4"
   },
   {
     "contractName": "SHA256",
     "bytecodePath": "contracts/precompiles/artifacts/SHA256.yul/SHA256.yul.zbin",
     "sourceCodePath": "contracts/precompiles/SHA256.yul",
-    "bytecodeHash": "0x01000017be3282e7a827dae855274848ffa158a98cd3abc71b2ce8a59e233926",
+    "bytecodeHash": "0x010000178d93b2d7d6448866009892223caf018a8e8dbcf090c2b9053a285f8d",
     "sourceCodeHash": "0x8f5a719394836111c850774e89ffb22ef825ff4d24d116ca750888be906f0109"
   },
   {
     "contractName": "bootloader_test",
     "bytecodePath": "bootloader/build/artifacts/bootloader_test.yul/bootloader_test.yul.zbin",
     "sourceCodePath": "bootloader/build/bootloader_test.yul",
-    "bytecodeHash": "0x010003410a35e314d9fc984efb4a8fed22ea61c7c7a7039f35de3990c21c960c",
+    "bytecodeHash": "0x0100037b0462ed355364eaabccbea2a018afad4c8841b9856514c027400f1b10",
     "sourceCodeHash": "0x467a36057882d6740a016cda812798d1be9a0ea60cb7ef90996e2c5be55e75a4"
   },
   {
     "contractName": "fee_estimate",
     "bytecodePath": "bootloader/build/artifacts/fee_estimate.yul/fee_estimate.yul.zbin",
     "sourceCodePath": "bootloader/build/fee_estimate.yul",
-    "bytecodeHash": "0x010007efea912e51b553499af9d8d4f197a0d75c46558f58757f085ab5bd94ef",
+    "bytecodeHash": "0x010009434283c0bc9f32e51a9aa84523ee7a381e3e0c5ae63f639998d915f54b",
     "sourceCodeHash": "0x3fb415ac6f59c35ea17b85aabb551df1b44a6fc7e051c2e33f5fc76c17432167"
   },
   {
     "contractName": "gas_test",
     "bytecodePath": "bootloader/build/artifacts/gas_test.yul/gas_test.yul.zbin",
     "sourceCodePath": "bootloader/build/gas_test.yul",
-    "bytecodeHash": "0x010007c381ab8f0f6e78bad7173547403df3d651fe0677fac57054c70c33f345",
+    "bytecodeHash": "0x01000927ea81a1afe5a586853a9c43fb928bcf1f1fba51a19c48ce1b940867c7",
     "sourceCodeHash": "0x84648c958714d952248b8553456b5a5e3860e00871f01644297531e991a67d64"
   },
   {
     "contractName": "playground_batch",
     "bytecodePath": "bootloader/build/artifacts/playground_batch.yul/playground_batch.yul.zbin",
     "sourceCodePath": "bootloader/build/playground_batch.yul",
-    "bytecodeHash": "0x010007f77d1146b93417590d684f7e40f5b0b50048431e38447384555b0714cb",
+    "bytecodeHash": "0x0100094d801bf4180d020692a95cf26a3c9adcaedfd5be47ec08b1637b0282da",
     "sourceCodeHash": "0xe02bed16015da2f03dcf5a7ed1bf2132009e69f4bfb5335e13cc406327e84d5e"
   },
   {
     "contractName": "proved_batch",
     "bytecodePath": "bootloader/build/artifacts/proved_batch.yul/proved_batch.yul.zbin",
     "sourceCodePath": "bootloader/build/proved_batch.yul",
-    "bytecodeHash": "0x010007dfc731fd12f861936e39ebb6ffae76e510261bb7e4d1ae2bc5a61de456",
+    "bytecodeHash": "0x010009411d9c2342671c57d5ce038ce3e142c750df85ac5d23f67b4e4215fede",
     "sourceCodeHash": "0xd48e5abbfbb493eacfcbe6dc788eada867d58ab8596d55736b496b1c2e22c636"
   }
 ]

--- a/SystemContractsHashes.json
+++ b/SystemContractsHashes.json
@@ -3,175 +3,175 @@
     "contractName": "AccountCodeStorage",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/AccountCodeStorage.sol/AccountCodeStorage.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/AccountCodeStorage.sol",
-    "bytecodeHash": "0x0100009b3cd9a137912ffbd406a1d73eaffbcf40a760f3956fea7e051f0c6101",
-    "sourceCodeHash": "0xf56f18d6ccec4a1e083ece9d5dea511b610905b3be42bf81e81e53f8a7028162"
+    "bytecodeHash": "0x0100007516973f1ad37fd05bcc2f86101909a85c565e2e0862e9a69d6996d176",
+    "sourceCodeHash": "0xb7a285eceef853b5259266de51584c7120fdc0335657b457c63a331301c96d8f"
   },
   {
     "contractName": "BootloaderUtilities",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/BootloaderUtilities.sol/BootloaderUtilities.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/BootloaderUtilities.sol",
-    "bytecodeHash": "0x01000975e811c2ba4a3b28f70426598129f0029feb086714980f9513f59531c7",
-    "sourceCodeHash": "0xcb8d18786a9dca90524de992e3216f57d89192600c2aa758f071a6a6ae3162c4"
+    "bytecodeHash": "0x010007dd45596adcedb61dbb9f68569b8e65bfd0a748655cef0805a686363311",
+    "sourceCodeHash": "0xf40ae3c82f6eb7b88e4d926c706c3edc3c2ce07bb60f60cd21accd228f38c212"
   },
   {
     "contractName": "ComplexUpgrader",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/ComplexUpgrader.sol/ComplexUpgrader.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/ComplexUpgrader.sol",
-    "bytecodeHash": "0x0100005b2eef785c804dc40ec24b3c2339b11a314fec6eb91db551a2523d6a2b",
-    "sourceCodeHash": "0x02b3234b8aa3dde88cf2cf6c1447512dd953ed355be9ba21c22d48ca6d3eee67"
+    "bytecodeHash": "0x010000559a8038d9ebf9cb91abb48345f8ec67395617c0614787a298181bf8ba",
+    "sourceCodeHash": "0xbf583b121fde4d406912afa7af7943adb440e355fcbf476f5b454c58fd07eda0"
   },
   {
     "contractName": "Compressor",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/Compressor.sol/Compressor.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/Compressor.sol",
-    "bytecodeHash": "0x010001b7a7bb988e52b8fca05d82bccf63ea34c6617ebea1765c91e911386756",
-    "sourceCodeHash": "0x214a2b123ecdf3b135709d0b6207b3d41d9e8c68a0aa74b88c64fc983382d7b0"
+    "bytecodeHash": "0x01000167e557f0f5b6fd5c7543d7b5e3398070ded2f1cfdf9bf00b82f3a60395",
+    "sourceCodeHash": "0xba41d1e46cd62c08f61ac78b693e5adbb5428f33640e0e55ff58cbd04093cd07"
   },
   {
     "contractName": "ContractDeployer",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/ContractDeployer.sol/ContractDeployer.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/ContractDeployer.sol",
-    "bytecodeHash": "0x010005bb3e1bb343565920b37c6c0d716dcfca45bbdada20a305e80ab60a6916",
-    "sourceCodeHash": "0xed9088758b3cbc9c450da0ac18e0e11359efe7341219ac1c331a4f5712c2dacb"
+    "bytecodeHash": "0x0100051bbd5dfd67950e195d6605d235a52bd9bb3723a8f34c47993609c0e164",
+    "sourceCodeHash": "0x99e484499462d7caea209e8386bd09dad1387c60d5034f3acdccc7b271b1c764"
   },
   {
     "contractName": "DefaultAccount",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/DefaultAccount.sol/DefaultAccount.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/DefaultAccount.sol",
-    "bytecodeHash": "0x0100065d0ea6130f484f6cd4936f2d5114abc9961328d6acd8b311dd00b94546",
-    "sourceCodeHash": "0x34aaf3d8fbe90cf35efcfa5d8361de8a97be0a7cb60b9b117cda0dfd78fab6a6"
+    "bytecodeHash": "0x0100055bf820db07101286892a8f28aa4744005cfe66e716cd91747acce1cb71",
+    "sourceCodeHash": "0xb30019238c2b8574e2a87960f4eed241548c0599c0eb5a6420d1d24d63377210"
   },
   {
     "contractName": "EmptyContract",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/EmptyContract.sol/EmptyContract.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/EmptyContract.sol",
-    "bytecodeHash": "0x01000007c08e60bc60d70f759bc49f2488b70054b0cec1a64f0cf27953448f4c",
-    "sourceCodeHash": "0x34cf9324829a0a1653486242a5dbee58aa93a8b9888415791bafe2c7a966400d"
+    "bytecodeHash": "0x0100000755a7b3a125cc9d9124000baae5e5a0644e7605d167e6f88ce89ec855",
+    "sourceCodeHash": "0x8bb626635c3cab6c5fc3b83e2ce09f98a8193ecdf019653bbe55d6cae3138b5d"
   },
   {
     "contractName": "ImmutableSimulator",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/ImmutableSimulator.sol/ImmutableSimulator.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/ImmutableSimulator.sol",
-    "bytecodeHash": "0x01000047b7e40b0e0f7bd7051e20853a49b972c6c0ac16872425067cb3288f08",
-    "sourceCodeHash": "0x315e71df564977165decbbbda504fee9d3dd98b6ca1e5dc68572d74bc308b03f"
+    "bytecodeHash": "0x0100003ffeda445065d1af6cafb152d1b90f6f4eec8e9af393bd73cffb8d59eb",
+    "sourceCodeHash": "0x8d1f252875fe4a8a1cd51bf7bd678b9bff7542bb468f75929cea69df4a16850d"
   },
   {
     "contractName": "KnownCodesStorage",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/KnownCodesStorage.sol/KnownCodesStorage.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/KnownCodesStorage.sol",
-    "bytecodeHash": "0x0100008b806f904a40cadb94318db1d8a8ae9a579f46ee0b50432e4c221572ee",
-    "sourceCodeHash": "0x33c7e9af04650d7e802ecfcf099fefde1ddb1a4268f521c0d69dea014ce5853d"
+    "bytecodeHash": "0x0100007d8202b8943737d03bebe18464b6fd8c473c7aeeff0bb49e58e408e138",
+    "sourceCodeHash": "0x15cb53060dad4c62e72c62777ff6a25029c6ec0ab37adacb684d0e275cec6749"
   },
   {
     "contractName": "L1Messenger",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/L1Messenger.sol/L1Messenger.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/L1Messenger.sol",
-    "bytecodeHash": "0x010002fb863dc09dbfdae276418c307eb39af03f335a0b23a2edc8bcd1835fce",
-    "sourceCodeHash": "0x1c355d04ecf4e4c39ab6481f2bb17e5e30d3aa4563342aaa4c9aa122ac3a14d3"
+    "bytecodeHash": "0x01000289b678909f8a11d0e6df9c21f91603ff1fdcfbb4919ad2d9196b2cf2ec",
+    "sourceCodeHash": "0x3dce2fc308f7d911a2d80460b895322f954f43ed6bca1893f34ae3469c05b222"
   },
   {
     "contractName": "L2EthToken",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/L2EthToken.sol/L2EthToken.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/L2EthToken.sol",
-    "bytecodeHash": "0x01000139b0930df0818b0f10f7c78feed9ca93020efcb72e749a7ea842d08576",
-    "sourceCodeHash": "0xb8e404a5e82c50b9f0cfb6412049d1174df3fbe8af40750a756ad0c1cfefb593"
+    "bytecodeHash": "0x0100010331035309eaed8e5c8ee8e7e72260ca24badf42bc916a7e0a7826a9cb",
+    "sourceCodeHash": "0xadc69be5b5799d0f1a6fa71d56a6706b146447c8e3c6516a5191a0b23bd134e8"
   },
   {
     "contractName": "MsgValueSimulator",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/MsgValueSimulator.sol/MsgValueSimulator.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/MsgValueSimulator.sol",
-    "bytecodeHash": "0x0100006f5dab2685a586d5ebbd360a2c1c2d593df1ab8267d8e172d92a202bfa",
-    "sourceCodeHash": "0x038cc8e7fe97ad4befa2d5ab4ae77fdefdecc20338142565b8086cd9342868ef"
+    "bytecodeHash": "0x01000063875cce9ea833c97442d2f83db53fce6ff0ea73bc1945757eef19b908",
+    "sourceCodeHash": "0xe7a85dc51512cab431d12bf062847c4dcf2f1c867e7d547ff95638f6a4e8fd4e"
   },
   {
     "contractName": "NonceHolder",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/NonceHolder.sol/NonceHolder.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/NonceHolder.sol",
-    "bytecodeHash": "0x0100012f7252eee16af884775bd3279b577bbed64f124349ac6179aeb6ae3cb8",
-    "sourceCodeHash": "0xdfdd234e9d7f6cc7dfb0b9c8b6a2dea3dc40204539bfb836c9ae2bb1dc9cbb1f"
+    "bytecodeHash": "0x010000e5cc02451d85f48498359034c9d4926aec7219e60803d832f490d7be53",
+    "sourceCodeHash": "0x04da0e5560c6cca2d0d5c965ee67d4cae9273367b77afef106108d4e8a2624b5"
   },
   {
     "contractName": "SystemContext",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/SystemContext.sol/SystemContext.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/SystemContext.sol",
-    "bytecodeHash": "0x0100023f1761d12df53e8581fabcb359cb069bbd2a7a7a3ef0b49f2f5d46169a",
-    "sourceCodeHash": "0x60d9007efb7f1bf9417f0856f3799937357a64c2e5f858d13d3ee584e8b9832e"
+    "bytecodeHash": "0x010001894fd125f294f86904dfb4358e81f1d7a6f83807994c3f029872f072d5",
+    "sourceCodeHash": "0x422768c771c4e4c077b66b9c4dd36e6dbeda4da058698ece239a0ad95b316646"
   },
   {
     "contractName": "EventWriter",
     "bytecodePath": "contracts/artifacts/EventWriter.yul/EventWriter.yul.zbin",
     "sourceCodePath": "contracts/EventWriter.yul",
-    "bytecodeHash": "0x01000019642d87621fdd82cf65aa9146486c9256d5f8849af9a37c78ef519339",
+    "bytecodeHash": "0x0100001704e8d1d46fcfd6da6e0c7c908b3044a0ef1cb1c2dd1017e319eedc85",
     "sourceCodeHash": "0x55cfee65f174350edfd690c949bc0a29458f25da11f1d5f90b57621567df1fc3"
   },
   {
     "contractName": "EcAdd",
     "bytecodePath": "contracts/precompiles/artifacts/EcAdd.yul/EcAdd.yul.zbin",
     "sourceCodePath": "contracts/precompiles/EcAdd.yul",
-    "bytecodeHash": "0x010000c56c054a0de4a36b133d3c114ec514c3ce0334ad7759c202392386a913",
+    "bytecodeHash": "0x010000c122358451b5dbb05598367816e79f73ad84493314683b085c0b2de491",
     "sourceCodeHash": "0xe73c8960a8b4060113adca9f03207d379580d172df9f0b499dd5353934a557a6"
   },
   {
     "contractName": "EcMul",
     "bytecodePath": "contracts/precompiles/artifacts/EcMul.yul/EcMul.yul.zbin",
     "sourceCodePath": "contracts/precompiles/EcMul.yul",
-    "bytecodeHash": "0x010001378d31273c8e58caa12bcf1a5694e66a0aefdba2504adb8e3eb02b21c7",
+    "bytecodeHash": "0x0100012bb789c1c70f50bafa5b92e5b987495ed53695cecfbe4444583b50372c",
     "sourceCodeHash": "0x6c4b11542bcf85e6e02ca193fc0548353b1f21c27e972b9e73781e8f7eaf50b0"
   },
   {
     "contractName": "Ecrecover",
     "bytecodePath": "contracts/precompiles/artifacts/Ecrecover.yul/Ecrecover.yul.zbin",
     "sourceCodePath": "contracts/precompiles/Ecrecover.yul",
-    "bytecodeHash": "0x010000114daca2ff44f27d543b8ef67d885bfed09a74ba9cb25f5912dd3d739c",
+    "bytecodeHash": "0x01000011f73843169ea4bd062afd909ea3b7b04efe4b1e69fb8d3a83d01f4ad4",
     "sourceCodeHash": "0x18eac0a993afec4112da99fc8e2978891598ab12566528628896f430c855fb81"
   },
   {
     "contractName": "Keccak256",
     "bytecodePath": "contracts/precompiles/artifacts/Keccak256.yul/Keccak256.yul.zbin",
     "sourceCodePath": "contracts/precompiles/Keccak256.yul",
-    "bytecodeHash": "0x0100001fb52ca33668d01c230a1c3b13ede90fe2e37d77222410e9f183cb7a89",
+    "bytecodeHash": "0x0100001f09b3d2e8a832b0a7f27fa2bf41594a286b0e7601503d3cb1918d165c",
     "sourceCodeHash": "0x6415e127a4e07907fb87d0cbdf480fff8c70326c4f2f670af0cf3248862e4df4"
   },
   {
     "contractName": "SHA256",
     "bytecodePath": "contracts/precompiles/artifacts/SHA256.yul/SHA256.yul.zbin",
     "sourceCodePath": "contracts/precompiles/SHA256.yul",
-    "bytecodeHash": "0x010000178d93b2d7d6448866009892223caf018a8e8dbcf090c2b9053a285f8d",
+    "bytecodeHash": "0x01000017be3282e7a827dae855274848ffa158a98cd3abc71b2ce8a59e233926",
     "sourceCodeHash": "0x8f5a719394836111c850774e89ffb22ef825ff4d24d116ca750888be906f0109"
   },
   {
     "contractName": "bootloader_test",
     "bytecodePath": "bootloader/build/artifacts/bootloader_test.yul/bootloader_test.yul.zbin",
     "sourceCodePath": "bootloader/build/bootloader_test.yul",
-    "bytecodeHash": "0x0100037b0462ed355364eaabccbea2a018afad4c8841b9856514c027400f1b10",
+    "bytecodeHash": "0x010003410a35e314d9fc984efb4a8fed22ea61c7c7a7039f35de3990c21c960c",
     "sourceCodeHash": "0x467a36057882d6740a016cda812798d1be9a0ea60cb7ef90996e2c5be55e75a4"
   },
   {
     "contractName": "fee_estimate",
     "bytecodePath": "bootloader/build/artifacts/fee_estimate.yul/fee_estimate.yul.zbin",
     "sourceCodePath": "bootloader/build/fee_estimate.yul",
-    "bytecodeHash": "0x010009434283c0bc9f32e51a9aa84523ee7a381e3e0c5ae63f639998d915f54b",
+    "bytecodeHash": "0x010007efea912e51b553499af9d8d4f197a0d75c46558f58757f085ab5bd94ef",
     "sourceCodeHash": "0x3fb415ac6f59c35ea17b85aabb551df1b44a6fc7e051c2e33f5fc76c17432167"
   },
   {
     "contractName": "gas_test",
     "bytecodePath": "bootloader/build/artifacts/gas_test.yul/gas_test.yul.zbin",
     "sourceCodePath": "bootloader/build/gas_test.yul",
-    "bytecodeHash": "0x01000927ea81a1afe5a586853a9c43fb928bcf1f1fba51a19c48ce1b940867c7",
+    "bytecodeHash": "0x010007c381ab8f0f6e78bad7173547403df3d651fe0677fac57054c70c33f345",
     "sourceCodeHash": "0x84648c958714d952248b8553456b5a5e3860e00871f01644297531e991a67d64"
   },
   {
     "contractName": "playground_batch",
     "bytecodePath": "bootloader/build/artifacts/playground_batch.yul/playground_batch.yul.zbin",
     "sourceCodePath": "bootloader/build/playground_batch.yul",
-    "bytecodeHash": "0x0100094d801bf4180d020692a95cf26a3c9adcaedfd5be47ec08b1637b0282da",
+    "bytecodeHash": "0x010007f77d1146b93417590d684f7e40f5b0b50048431e38447384555b0714cb",
     "sourceCodeHash": "0xe02bed16015da2f03dcf5a7ed1bf2132009e69f4bfb5335e13cc406327e84d5e"
   },
   {
     "contractName": "proved_batch",
     "bytecodePath": "bootloader/build/artifacts/proved_batch.yul/proved_batch.yul.zbin",
     "sourceCodePath": "bootloader/build/proved_batch.yul",
-    "bytecodeHash": "0x010009411d9c2342671c57d5ce038ce3e142c750df85ac5d23f67b4e4215fede",
+    "bytecodeHash": "0x010007dfc731fd12f861936e39ebb6ffae76e510261bb7e4d1ae2bc5a61de456",
     "sourceCodeHash": "0xd48e5abbfbb493eacfcbe6dc788eada867d58ab8596d55736b496b1c2e22c636"
   }
 ]

--- a/SystemContractsHashes.json
+++ b/SystemContractsHashes.json
@@ -3,42 +3,42 @@
     "contractName": "AccountCodeStorage",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/AccountCodeStorage.sol/AccountCodeStorage.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/AccountCodeStorage.sol",
-    "bytecodeHash": "0x0100009b175ab666eac6aebd5540b5d97d0b867e58dfd78ac28b326841475aee",
+    "bytecodeHash": "0x0100009b9ca53b692a374520c5fa42b54395e71f03b06db62922a61edad50e7d",
     "sourceCodeHash": "0xb7a285eceef853b5259266de51584c7120fdc0335657b457c63a331301c96d8f"
   },
   {
     "contractName": "BootloaderUtilities",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/BootloaderUtilities.sol/BootloaderUtilities.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/BootloaderUtilities.sol",
-    "bytecodeHash": "0x010009754240bc8ff438f892d6e90695fae5a45895750b185ca45d1d7148498e",
+    "bytecodeHash": "0x01000975aa1d6323aa715c4ed92458882e8ca4d2b37eab3bf6770b60a6182f6a",
     "sourceCodeHash": "0xf40ae3c82f6eb7b88e4d926c706c3edc3c2ce07bb60f60cd21accd228f38c212"
   },
   {
     "contractName": "ComplexUpgrader",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/ComplexUpgrader.sol/ComplexUpgrader.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/ComplexUpgrader.sol",
-    "bytecodeHash": "0x0100005b2459f497f705e6956088748d082cd19aead231f82baaa441fb41d518",
+    "bytecodeHash": "0x0100005bad258d9c07ebd112f2951cbb4aa4be367a481d311563c9c9ca80b2d9",
     "sourceCodeHash": "0xbf583b121fde4d406912afa7af7943adb440e355fcbf476f5b454c58fd07eda0"
   },
   {
     "contractName": "Compressor",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/Compressor.sol/Compressor.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/Compressor.sol",
-    "bytecodeHash": "0x010001b7f55ea4f3ce8fa1c6a8a483f7773d54397b4c52a5f159485562ba37bd",
+    "bytecodeHash": "0x010001b7a20def59f4f9de9d6b867f8d1b9be7919b556c3b59518c3702aec838",
     "sourceCodeHash": "0xba41d1e46cd62c08f61ac78b693e5adbb5428f33640e0e55ff58cbd04093cd07"
   },
   {
     "contractName": "ContractDeployer",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/ContractDeployer.sol/ContractDeployer.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/ContractDeployer.sol",
-    "bytecodeHash": "0x010005bbbdd733760a538d99b6a9569c9abbbb03e1687ef71fdf09ffbef76aaf",
+    "bytecodeHash": "0x010005bb18194a3c6d029f5a8787f051595cec6b1a8ad2791e922bf240053dcc",
     "sourceCodeHash": "0x99e484499462d7caea209e8386bd09dad1387c60d5034f3acdccc7b271b1c764"
   },
   {
     "contractName": "DefaultAccount",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/DefaultAccount.sol/DefaultAccount.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/DefaultAccount.sol",
-    "bytecodeHash": "0x0100065dd78052e25d9a27d81f1ff52c11ee1bffd85998f8a339b419ff3a3a1a",
+    "bytecodeHash": "0x0100065d36f395889bda1ffc649d545c0ffeecde42c0ad88934dd6618a990038",
     "sourceCodeHash": "0xb30019238c2b8574e2a87960f4eed241548c0599c0eb5a6420d1d24d63377210"
   },
   {
@@ -52,49 +52,49 @@
     "contractName": "ImmutableSimulator",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/ImmutableSimulator.sol/ImmutableSimulator.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/ImmutableSimulator.sol",
-    "bytecodeHash": "0x010000475e421f56cf54cdbf60997ed12aad55cc9e0b8e3b84ed43a27c1a6d9d",
+    "bytecodeHash": "0x01000047fdc45d38eb26108fafd99a8dda122e6540e4fb566fe7ce2c54090752",
     "sourceCodeHash": "0x8d1f252875fe4a8a1cd51bf7bd678b9bff7542bb468f75929cea69df4a16850d"
   },
   {
     "contractName": "KnownCodesStorage",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/KnownCodesStorage.sol/KnownCodesStorage.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/KnownCodesStorage.sol",
-    "bytecodeHash": "0x0100008b5f445f1769b9914d9e58f324cb5908b33ea2dd91584dc1919aa8431f",
+    "bytecodeHash": "0x0100008b953a05a94540c7ad5082a5a67a023651a1dbe2d0fb832a6d7fbeb893",
     "sourceCodeHash": "0x15cb53060dad4c62e72c62777ff6a25029c6ec0ab37adacb684d0e275cec6749"
   },
   {
     "contractName": "L1Messenger",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/L1Messenger.sol/L1Messenger.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/L1Messenger.sol",
-    "bytecodeHash": "0x010002fbc517590966080d4440c139e35b8a411f503cac206163c0256c3aa5bf",
+    "bytecodeHash": "0x010002fbdc855bdd1ac421a66db258ab77b450b2a16e295e5dd56cd6aaecc69a",
     "sourceCodeHash": "0x3dce2fc308f7d911a2d80460b895322f954f43ed6bca1893f34ae3469c05b222"
   },
   {
     "contractName": "L2EthToken",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/L2EthToken.sol/L2EthToken.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/L2EthToken.sol",
-    "bytecodeHash": "0x01000139335e820a31a7dd9706d29589db9cd0dc5ba9efd0ff3d303a853064a1",
+    "bytecodeHash": "0x0100013900f1639f08f90edbe93e8e00166a8dc2443a7a7f77e43b282c5529c1",
     "sourceCodeHash": "0xadc69be5b5799d0f1a6fa71d56a6706b146447c8e3c6516a5191a0b23bd134e8"
   },
   {
     "contractName": "MsgValueSimulator",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/MsgValueSimulator.sol/MsgValueSimulator.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/MsgValueSimulator.sol",
-    "bytecodeHash": "0x0100006f336d39b95b20fb01e9661bf8145beff9e3bd5e97d1fa96ccaf8f7307",
+    "bytecodeHash": "0x0100006fd1a3e535db02c2e8ff8e9cadd52aab1bde05980ab828b568e9efd8e1",
     "sourceCodeHash": "0xe7a85dc51512cab431d12bf062847c4dcf2f1c867e7d547ff95638f6a4e8fd4e"
   },
   {
     "contractName": "NonceHolder",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/NonceHolder.sol/NonceHolder.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/NonceHolder.sol",
-    "bytecodeHash": "0x0100012f7ffee4eb58ec639a3269a35bc5065a24f5221c2d5993bf6b69b7d3c3",
+    "bytecodeHash": "0x0100012fba56e2fa8880eb52fd8db2b49ee7ee85bbfad241606097508f308f4d",
     "sourceCodeHash": "0x04da0e5560c6cca2d0d5c965ee67d4cae9273367b77afef106108d4e8a2624b5"
   },
   {
     "contractName": "SystemContext",
     "bytecodePath": "artifacts-zk/cache-zk/solpp-generated-contracts/SystemContext.sol/SystemContext.json",
     "sourceCodePath": "cache-zk/solpp-generated-contracts/SystemContext.sol",
-    "bytecodeHash": "0x0100023f2225bb3fc545271d5020934b26396f6c66256229ae286f4372ca3116",
+    "bytecodeHash": "0x0100023fd8d36304cec41afa8b726686170552b660d0202970b0ecc4ceab8c3a",
     "sourceCodeHash": "0x422768c771c4e4c077b66b9c4dd36e6dbeda4da058698ece239a0ad95b316646"
   },
   {

--- a/contracts/AccountCodeStorage.sol
+++ b/contracts/AccountCodeStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import "./interfaces/IAccountCodeStorage.sol";
 import "./libraries/Utils.sol";

--- a/contracts/AccountCodeStorage.sol
+++ b/contracts/AccountCodeStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import "./interfaces/IAccountCodeStorage.sol";
 import "./libraries/Utils.sol";

--- a/contracts/AccountCodeStorage.sol
+++ b/contracts/AccountCodeStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import "./interfaces/IAccountCodeStorage.sol";
 import "./libraries/Utils.sol";

--- a/contracts/AccountCodeStorage.sol
+++ b/contracts/AccountCodeStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "./interfaces/IAccountCodeStorage.sol";
 import "./libraries/Utils.sol";

--- a/contracts/BootloaderUtilities.sol
+++ b/contracts/BootloaderUtilities.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import "./interfaces/IBootloaderUtilities.sol";
 import "./libraries/TransactionHelper.sol";

--- a/contracts/BootloaderUtilities.sol
+++ b/contracts/BootloaderUtilities.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import "./interfaces/IBootloaderUtilities.sol";
 import "./libraries/TransactionHelper.sol";

--- a/contracts/BootloaderUtilities.sol
+++ b/contracts/BootloaderUtilities.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import "./interfaces/IBootloaderUtilities.sol";
 import "./libraries/TransactionHelper.sol";

--- a/contracts/BootloaderUtilities.sol
+++ b/contracts/BootloaderUtilities.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "./interfaces/IBootloaderUtilities.sol";
 import "./libraries/TransactionHelper.sol";

--- a/contracts/ComplexUpgrader.sol
+++ b/contracts/ComplexUpgrader.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import {IComplexUpgrader} from "./interfaces/IComplexUpgrader.sol";
 import {FORCE_DEPLOYER} from "./Constants.sol";

--- a/contracts/ComplexUpgrader.sol
+++ b/contracts/ComplexUpgrader.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import {IComplexUpgrader} from "./interfaces/IComplexUpgrader.sol";
 import {FORCE_DEPLOYER} from "./Constants.sol";

--- a/contracts/ComplexUpgrader.sol
+++ b/contracts/ComplexUpgrader.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import {IComplexUpgrader} from "./interfaces/IComplexUpgrader.sol";
 import {FORCE_DEPLOYER} from "./Constants.sol";

--- a/contracts/ComplexUpgrader.sol
+++ b/contracts/ComplexUpgrader.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import {IComplexUpgrader} from "./interfaces/IComplexUpgrader.sol";
 import {FORCE_DEPLOYER} from "./Constants.sol";

--- a/contracts/Compressor.sol
+++ b/contracts/Compressor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import {ICompressor, OPERATION_BITMASK, LENGTH_BITS_OFFSET, MAX_ENUMERATION_INDEX_SIZE} from "./interfaces/ICompressor.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/Compressor.sol
+++ b/contracts/Compressor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import {ICompressor, OPERATION_BITMASK, LENGTH_BITS_OFFSET, MAX_ENUMERATION_INDEX_SIZE} from "./interfaces/ICompressor.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/Compressor.sol
+++ b/contracts/Compressor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import {ICompressor, OPERATION_BITMASK, LENGTH_BITS_OFFSET, MAX_ENUMERATION_INDEX_SIZE} from "./interfaces/ICompressor.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/Compressor.sol
+++ b/contracts/Compressor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import {ICompressor, OPERATION_BITMASK, LENGTH_BITS_OFFSET, MAX_ENUMERATION_INDEX_SIZE} from "./interfaces/ICompressor.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/Constants.sol
+++ b/contracts/Constants.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import {IAccountCodeStorage} from "./interfaces/IAccountCodeStorage.sol";
 import {INonceHolder} from "./interfaces/INonceHolder.sol";

--- a/contracts/Constants.sol
+++ b/contracts/Constants.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import {IAccountCodeStorage} from "./interfaces/IAccountCodeStorage.sol";
 import {INonceHolder} from "./interfaces/INonceHolder.sol";

--- a/contracts/Constants.sol
+++ b/contracts/Constants.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import {IAccountCodeStorage} from "./interfaces/IAccountCodeStorage.sol";
 import {INonceHolder} from "./interfaces/INonceHolder.sol";

--- a/contracts/Constants.sol
+++ b/contracts/Constants.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import {IAccountCodeStorage} from "./interfaces/IAccountCodeStorage.sol";
 import {INonceHolder} from "./interfaces/INonceHolder.sol";

--- a/contracts/ContractDeployer.sol
+++ b/contracts/ContractDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import {ImmutableData} from "./interfaces/IImmutableSimulator.sol";
 import {IContractDeployer} from "./interfaces/IContractDeployer.sol";

--- a/contracts/ContractDeployer.sol
+++ b/contracts/ContractDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import {ImmutableData} from "./interfaces/IImmutableSimulator.sol";
 import {IContractDeployer} from "./interfaces/IContractDeployer.sol";

--- a/contracts/ContractDeployer.sol
+++ b/contracts/ContractDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import {ImmutableData} from "./interfaces/IImmutableSimulator.sol";
 import {IContractDeployer} from "./interfaces/IContractDeployer.sol";

--- a/contracts/ContractDeployer.sol
+++ b/contracts/ContractDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import {ImmutableData} from "./interfaces/IImmutableSimulator.sol";
 import {IContractDeployer} from "./interfaces/IContractDeployer.sol";

--- a/contracts/DefaultAccount.sol
+++ b/contracts/DefaultAccount.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import "./interfaces/IAccount.sol";
 import "./libraries/TransactionHelper.sol";

--- a/contracts/DefaultAccount.sol
+++ b/contracts/DefaultAccount.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import "./interfaces/IAccount.sol";
 import "./libraries/TransactionHelper.sol";

--- a/contracts/DefaultAccount.sol
+++ b/contracts/DefaultAccount.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "./interfaces/IAccount.sol";
 import "./libraries/TransactionHelper.sol";

--- a/contracts/DefaultAccount.sol
+++ b/contracts/DefaultAccount.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import "./interfaces/IAccount.sol";
 import "./libraries/TransactionHelper.sol";

--- a/contracts/EmptyContract.sol
+++ b/contracts/EmptyContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 /**
  * @author Matter Labs

--- a/contracts/EmptyContract.sol
+++ b/contracts/EmptyContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/EmptyContract.sol
+++ b/contracts/EmptyContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/EmptyContract.sol
+++ b/contracts/EmptyContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/ImmutableSimulator.sol
+++ b/contracts/ImmutableSimulator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import "./interfaces/IImmutableSimulator.sol";
 import {DEPLOYER_SYSTEM_CONTRACT} from "./Constants.sol";

--- a/contracts/ImmutableSimulator.sol
+++ b/contracts/ImmutableSimulator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import "./interfaces/IImmutableSimulator.sol";
 import {DEPLOYER_SYSTEM_CONTRACT} from "./Constants.sol";

--- a/contracts/ImmutableSimulator.sol
+++ b/contracts/ImmutableSimulator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "./interfaces/IImmutableSimulator.sol";
 import {DEPLOYER_SYSTEM_CONTRACT} from "./Constants.sol";

--- a/contracts/ImmutableSimulator.sol
+++ b/contracts/ImmutableSimulator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import "./interfaces/IImmutableSimulator.sol";
 import {DEPLOYER_SYSTEM_CONTRACT} from "./Constants.sol";

--- a/contracts/KnownCodesStorage.sol
+++ b/contracts/KnownCodesStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import {IKnownCodesStorage} from "./interfaces/IKnownCodesStorage.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/KnownCodesStorage.sol
+++ b/contracts/KnownCodesStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import {IKnownCodesStorage} from "./interfaces/IKnownCodesStorage.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/KnownCodesStorage.sol
+++ b/contracts/KnownCodesStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import {IKnownCodesStorage} from "./interfaces/IKnownCodesStorage.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/KnownCodesStorage.sol
+++ b/contracts/KnownCodesStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import {IKnownCodesStorage} from "./interfaces/IKnownCodesStorage.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/L1Messenger.sol
+++ b/contracts/L1Messenger.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import {IL1Messenger, L2ToL1Log, L2_L1_LOGS_TREE_DEFAULT_LEAF_HASH, L2_TO_L1_LOG_SERIALIZE_SIZE, STATE_DIFF_COMPRESSION_VERSION_NUMBER} from "./interfaces/IL1Messenger.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/L1Messenger.sol
+++ b/contracts/L1Messenger.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import {IL1Messenger, L2ToL1Log, L2_L1_LOGS_TREE_DEFAULT_LEAF_HASH, L2_TO_L1_LOG_SERIALIZE_SIZE, STATE_DIFF_COMPRESSION_VERSION_NUMBER} from "./interfaces/IL1Messenger.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/L1Messenger.sol
+++ b/contracts/L1Messenger.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import {IL1Messenger, L2ToL1Log, L2_L1_LOGS_TREE_DEFAULT_LEAF_HASH, L2_TO_L1_LOG_SERIALIZE_SIZE, STATE_DIFF_COMPRESSION_VERSION_NUMBER} from "./interfaces/IL1Messenger.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/L1Messenger.sol
+++ b/contracts/L1Messenger.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import {IL1Messenger, L2ToL1Log, L2_L1_LOGS_TREE_DEFAULT_LEAF_HASH, L2_TO_L1_LOG_SERIALIZE_SIZE, STATE_DIFF_COMPRESSION_VERSION_NUMBER} from "./interfaces/IL1Messenger.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/L2EthToken.sol
+++ b/contracts/L2EthToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import {IEthToken} from "./interfaces/IEthToken.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/L2EthToken.sol
+++ b/contracts/L2EthToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import {IEthToken} from "./interfaces/IEthToken.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/L2EthToken.sol
+++ b/contracts/L2EthToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import {IEthToken} from "./interfaces/IEthToken.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/L2EthToken.sol
+++ b/contracts/L2EthToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import {IEthToken} from "./interfaces/IEthToken.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/MsgValueSimulator.sol
+++ b/contracts/MsgValueSimulator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import "./libraries/Utils.sol";
 import "./libraries/EfficientCall.sol";

--- a/contracts/MsgValueSimulator.sol
+++ b/contracts/MsgValueSimulator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "./libraries/Utils.sol";
 import "./libraries/EfficientCall.sol";

--- a/contracts/MsgValueSimulator.sol
+++ b/contracts/MsgValueSimulator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import "./libraries/Utils.sol";
 import "./libraries/EfficientCall.sol";

--- a/contracts/MsgValueSimulator.sol
+++ b/contracts/MsgValueSimulator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import "./libraries/Utils.sol";
 import "./libraries/EfficientCall.sol";

--- a/contracts/NonceHolder.sol
+++ b/contracts/NonceHolder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import "./interfaces/INonceHolder.sol";
 import "./interfaces/IContractDeployer.sol";

--- a/contracts/NonceHolder.sol
+++ b/contracts/NonceHolder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import "./interfaces/INonceHolder.sol";
 import "./interfaces/IContractDeployer.sol";

--- a/contracts/NonceHolder.sol
+++ b/contracts/NonceHolder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "./interfaces/INonceHolder.sol";
 import "./interfaces/IContractDeployer.sol";

--- a/contracts/NonceHolder.sol
+++ b/contracts/NonceHolder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import "./interfaces/INonceHolder.sol";
 import "./interfaces/IContractDeployer.sol";

--- a/contracts/SystemContext.sol
+++ b/contracts/SystemContext.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import {ISystemContext} from "./interfaces/ISystemContext.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/SystemContext.sol
+++ b/contracts/SystemContext.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import {ISystemContext} from "./interfaces/ISystemContext.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/SystemContext.sol
+++ b/contracts/SystemContext.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import {ISystemContext} from "./interfaces/ISystemContext.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/SystemContext.sol
+++ b/contracts/SystemContext.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import {ISystemContext} from "./interfaces/ISystemContext.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/contracts/interfaces/IAccount.sol
+++ b/contracts/interfaces/IAccount.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "../libraries/TransactionHelper.sol";
 

--- a/contracts/interfaces/IAccount.sol
+++ b/contracts/interfaces/IAccount.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import "../libraries/TransactionHelper.sol";
 

--- a/contracts/interfaces/IAccount.sol
+++ b/contracts/interfaces/IAccount.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import "../libraries/TransactionHelper.sol";
 

--- a/contracts/interfaces/IAccount.sol
+++ b/contracts/interfaces/IAccount.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import "../libraries/TransactionHelper.sol";
 

--- a/contracts/interfaces/IAccountCodeStorage.sol
+++ b/contracts/interfaces/IAccountCodeStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 interface IAccountCodeStorage {
     function storeAccountConstructingCodeHash(address _address, bytes32 _hash) external;

--- a/contracts/interfaces/IAccountCodeStorage.sol
+++ b/contracts/interfaces/IAccountCodeStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 interface IAccountCodeStorage {
     function storeAccountConstructingCodeHash(address _address, bytes32 _hash) external;

--- a/contracts/interfaces/IAccountCodeStorage.sol
+++ b/contracts/interfaces/IAccountCodeStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 interface IAccountCodeStorage {
     function storeAccountConstructingCodeHash(address _address, bytes32 _hash) external;

--- a/contracts/interfaces/IAccountCodeStorage.sol
+++ b/contracts/interfaces/IAccountCodeStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 interface IAccountCodeStorage {
     function storeAccountConstructingCodeHash(address _address, bytes32 _hash) external;

--- a/contracts/interfaces/IBootloaderUtilities.sol
+++ b/contracts/interfaces/IBootloaderUtilities.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "../libraries/TransactionHelper.sol";
 

--- a/contracts/interfaces/IBootloaderUtilities.sol
+++ b/contracts/interfaces/IBootloaderUtilities.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import "../libraries/TransactionHelper.sol";
 

--- a/contracts/interfaces/IBootloaderUtilities.sol
+++ b/contracts/interfaces/IBootloaderUtilities.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import "../libraries/TransactionHelper.sol";
 

--- a/contracts/interfaces/IBootloaderUtilities.sol
+++ b/contracts/interfaces/IBootloaderUtilities.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import "../libraries/TransactionHelper.sol";
 

--- a/contracts/interfaces/IComplexUpgrader.sol
+++ b/contracts/interfaces/IComplexUpgrader.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 interface IComplexUpgrader {
     function upgrade(address _delegateTo, bytes calldata _calldata) external payable;

--- a/contracts/interfaces/IComplexUpgrader.sol
+++ b/contracts/interfaces/IComplexUpgrader.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 interface IComplexUpgrader {
     function upgrade(address _delegateTo, bytes calldata _calldata) external payable;

--- a/contracts/interfaces/IComplexUpgrader.sol
+++ b/contracts/interfaces/IComplexUpgrader.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 interface IComplexUpgrader {
     function upgrade(address _delegateTo, bytes calldata _calldata) external payable;

--- a/contracts/interfaces/IComplexUpgrader.sol
+++ b/contracts/interfaces/IComplexUpgrader.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 interface IComplexUpgrader {
     function upgrade(address _delegateTo, bytes calldata _calldata) external payable;

--- a/contracts/interfaces/ICompressor.sol
+++ b/contracts/interfaces/ICompressor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 // The bitmask by applying which to the compressed state diff metadata we retrieve its operation.
 uint8 constant OPERATION_BITMASK = 7;

--- a/contracts/interfaces/ICompressor.sol
+++ b/contracts/interfaces/ICompressor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 // The bitmask by applying which to the compressed state diff metadata we retrieve its operation.
 uint8 constant OPERATION_BITMASK = 7;

--- a/contracts/interfaces/ICompressor.sol
+++ b/contracts/interfaces/ICompressor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 // The bitmask by applying which to the compressed state diff metadata we retrieve its operation.
 uint8 constant OPERATION_BITMASK = 7;

--- a/contracts/interfaces/ICompressor.sol
+++ b/contracts/interfaces/ICompressor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 // The bitmask by applying which to the compressed state diff metadata we retrieve its operation.
 uint8 constant OPERATION_BITMASK = 7;

--- a/contracts/interfaces/IContractDeployer.sol
+++ b/contracts/interfaces/IContractDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 interface IContractDeployer {
     /// @notice Defines the version of the account abstraction protocol

--- a/contracts/interfaces/IContractDeployer.sol
+++ b/contracts/interfaces/IContractDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 interface IContractDeployer {
     /// @notice Defines the version of the account abstraction protocol

--- a/contracts/interfaces/IContractDeployer.sol
+++ b/contracts/interfaces/IContractDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 interface IContractDeployer {
     /// @notice Defines the version of the account abstraction protocol

--- a/contracts/interfaces/IContractDeployer.sol
+++ b/contracts/interfaces/IContractDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 interface IContractDeployer {
     /// @notice Defines the version of the account abstraction protocol

--- a/contracts/interfaces/IEthToken.sol
+++ b/contracts/interfaces/IEthToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 interface IEthToken {
     function balanceOf(uint256) external view returns (uint256);

--- a/contracts/interfaces/IEthToken.sol
+++ b/contracts/interfaces/IEthToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 interface IEthToken {
     function balanceOf(uint256) external view returns (uint256);

--- a/contracts/interfaces/IEthToken.sol
+++ b/contracts/interfaces/IEthToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 interface IEthToken {
     function balanceOf(uint256) external view returns (uint256);

--- a/contracts/interfaces/IEthToken.sol
+++ b/contracts/interfaces/IEthToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 interface IEthToken {
     function balanceOf(uint256) external view returns (uint256);

--- a/contracts/interfaces/IImmutableSimulator.sol
+++ b/contracts/interfaces/IImmutableSimulator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 struct ImmutableData {
     uint256 index;

--- a/contracts/interfaces/IImmutableSimulator.sol
+++ b/contracts/interfaces/IImmutableSimulator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 struct ImmutableData {
     uint256 index;

--- a/contracts/interfaces/IImmutableSimulator.sol
+++ b/contracts/interfaces/IImmutableSimulator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 struct ImmutableData {
     uint256 index;

--- a/contracts/interfaces/IImmutableSimulator.sol
+++ b/contracts/interfaces/IImmutableSimulator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 struct ImmutableData {
     uint256 index;

--- a/contracts/interfaces/IKnownCodesStorage.sol
+++ b/contracts/interfaces/IKnownCodesStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 interface IKnownCodesStorage {
     event MarkedAsKnown(bytes32 indexed bytecodeHash, bool indexed sendBytecodeToL1);

--- a/contracts/interfaces/IKnownCodesStorage.sol
+++ b/contracts/interfaces/IKnownCodesStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 interface IKnownCodesStorage {
     event MarkedAsKnown(bytes32 indexed bytecodeHash, bool indexed sendBytecodeToL1);

--- a/contracts/interfaces/IKnownCodesStorage.sol
+++ b/contracts/interfaces/IKnownCodesStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 interface IKnownCodesStorage {
     event MarkedAsKnown(bytes32 indexed bytecodeHash, bool indexed sendBytecodeToL1);

--- a/contracts/interfaces/IKnownCodesStorage.sol
+++ b/contracts/interfaces/IKnownCodesStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 interface IKnownCodesStorage {
     event MarkedAsKnown(bytes32 indexed bytecodeHash, bool indexed sendBytecodeToL1);

--- a/contracts/interfaces/IL1Messenger.sol
+++ b/contracts/interfaces/IL1Messenger.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 /// @dev The log passed from L2
 /// @param l2ShardId The shard identifier, 0 - rollup, 1 - porter. All other values are not used but are reserved for the future

--- a/contracts/interfaces/IL1Messenger.sol
+++ b/contracts/interfaces/IL1Messenger.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 /// @dev The log passed from L2
 /// @param l2ShardId The shard identifier, 0 - rollup, 1 - porter. All other values are not used but are reserved for the future

--- a/contracts/interfaces/IL1Messenger.sol
+++ b/contracts/interfaces/IL1Messenger.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 /// @dev The log passed from L2
 /// @param l2ShardId The shard identifier, 0 - rollup, 1 - porter. All other values are not used but are reserved for the future

--- a/contracts/interfaces/IL1Messenger.sol
+++ b/contracts/interfaces/IL1Messenger.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 /// @dev The log passed from L2
 /// @param l2ShardId The shard identifier, 0 - rollup, 1 - porter. All other values are not used but are reserved for the future

--- a/contracts/interfaces/IL2StandardToken.sol
+++ b/contracts/interfaces/IL2StandardToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 interface IL2StandardToken {
     event BridgeMint(address indexed _account, uint256 _amount);

--- a/contracts/interfaces/IL2StandardToken.sol
+++ b/contracts/interfaces/IL2StandardToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 interface IL2StandardToken {
     event BridgeMint(address indexed _account, uint256 _amount);

--- a/contracts/interfaces/IL2StandardToken.sol
+++ b/contracts/interfaces/IL2StandardToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 interface IL2StandardToken {
     event BridgeMint(address indexed _account, uint256 _amount);

--- a/contracts/interfaces/IL2StandardToken.sol
+++ b/contracts/interfaces/IL2StandardToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 interface IL2StandardToken {
     event BridgeMint(address indexed _account, uint256 _amount);

--- a/contracts/interfaces/IMailbox.sol
+++ b/contracts/interfaces/IMailbox.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 interface IMailbox {
     function finalizeEthWithdrawal(

--- a/contracts/interfaces/IMailbox.sol
+++ b/contracts/interfaces/IMailbox.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 interface IMailbox {
     function finalizeEthWithdrawal(

--- a/contracts/interfaces/IMailbox.sol
+++ b/contracts/interfaces/IMailbox.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 interface IMailbox {
     function finalizeEthWithdrawal(

--- a/contracts/interfaces/IMailbox.sol
+++ b/contracts/interfaces/IMailbox.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 interface IMailbox {
     function finalizeEthWithdrawal(

--- a/contracts/interfaces/INonceHolder.sol
+++ b/contracts/interfaces/INonceHolder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 /**
  * @author Matter Labs

--- a/contracts/interfaces/INonceHolder.sol
+++ b/contracts/interfaces/INonceHolder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/interfaces/INonceHolder.sol
+++ b/contracts/interfaces/INonceHolder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/interfaces/INonceHolder.sol
+++ b/contracts/interfaces/INonceHolder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/interfaces/IPaymaster.sol
+++ b/contracts/interfaces/IPaymaster.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "../libraries/TransactionHelper.sol";
 

--- a/contracts/interfaces/IPaymaster.sol
+++ b/contracts/interfaces/IPaymaster.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import "../libraries/TransactionHelper.sol";
 

--- a/contracts/interfaces/IPaymaster.sol
+++ b/contracts/interfaces/IPaymaster.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import "../libraries/TransactionHelper.sol";
 

--- a/contracts/interfaces/IPaymaster.sol
+++ b/contracts/interfaces/IPaymaster.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import "../libraries/TransactionHelper.sol";
 

--- a/contracts/interfaces/IPaymasterFlow.sol
+++ b/contracts/interfaces/IPaymasterFlow.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 /**
  * @author Matter Labs

--- a/contracts/interfaces/IPaymasterFlow.sol
+++ b/contracts/interfaces/IPaymasterFlow.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/interfaces/IPaymasterFlow.sol
+++ b/contracts/interfaces/IPaymasterFlow.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/interfaces/IPaymasterFlow.sol
+++ b/contracts/interfaces/IPaymasterFlow.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/interfaces/ISystemContext.sol
+++ b/contracts/interfaces/ISystemContext.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 /**
  * @author Matter Labs

--- a/contracts/interfaces/ISystemContext.sol
+++ b/contracts/interfaces/ISystemContext.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/interfaces/ISystemContext.sol
+++ b/contracts/interfaces/ISystemContext.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/interfaces/ISystemContext.sol
+++ b/contracts/interfaces/ISystemContext.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/interfaces/ISystemContextDeprecated.sol
+++ b/contracts/interfaces/ISystemContextDeprecated.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 /**
  * @author Matter Labs

--- a/contracts/interfaces/ISystemContextDeprecated.sol
+++ b/contracts/interfaces/ISystemContextDeprecated.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/interfaces/ISystemContextDeprecated.sol
+++ b/contracts/interfaces/ISystemContextDeprecated.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/interfaces/ISystemContextDeprecated.sol
+++ b/contracts/interfaces/ISystemContextDeprecated.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/interfaces/ISystemContract.sol
+++ b/contracts/interfaces/ISystemContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import {SystemContractHelper} from "../libraries/SystemContractHelper.sol";
 import {BOOTLOADER_FORMAL_ADDRESS} from "../Constants.sol";

--- a/contracts/interfaces/ISystemContract.sol
+++ b/contracts/interfaces/ISystemContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import {SystemContractHelper} from "../libraries/SystemContractHelper.sol";
 import {BOOTLOADER_FORMAL_ADDRESS} from "../Constants.sol";

--- a/contracts/interfaces/ISystemContract.sol
+++ b/contracts/interfaces/ISystemContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import {SystemContractHelper} from "../libraries/SystemContractHelper.sol";
 import {BOOTLOADER_FORMAL_ADDRESS} from "../Constants.sol";

--- a/contracts/interfaces/ISystemContract.sol
+++ b/contracts/interfaces/ISystemContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import {SystemContractHelper} from "../libraries/SystemContractHelper.sol";
 import {BOOTLOADER_FORMAL_ADDRESS} from "../Constants.sol";

--- a/contracts/libraries/EfficientCall.sol
+++ b/contracts/libraries/EfficientCall.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import "./SystemContractHelper.sol";
 import "./Utils.sol";

--- a/contracts/libraries/EfficientCall.sol
+++ b/contracts/libraries/EfficientCall.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "./SystemContractHelper.sol";
 import "./Utils.sol";

--- a/contracts/libraries/EfficientCall.sol
+++ b/contracts/libraries/EfficientCall.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import "./SystemContractHelper.sol";
 import "./Utils.sol";

--- a/contracts/libraries/EfficientCall.sol
+++ b/contracts/libraries/EfficientCall.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import "./SystemContractHelper.sol";
 import "./Utils.sol";

--- a/contracts/libraries/RLPEncoder.sol
+++ b/contracts/libraries/RLPEncoder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 /**
  * @author Matter Labs

--- a/contracts/libraries/RLPEncoder.sol
+++ b/contracts/libraries/RLPEncoder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/libraries/RLPEncoder.sol
+++ b/contracts/libraries/RLPEncoder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/libraries/RLPEncoder.sol
+++ b/contracts/libraries/RLPEncoder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/libraries/SystemContractHelper.sol
+++ b/contracts/libraries/SystemContractHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import {MAX_SYSTEM_CONTRACT_ADDRESS} from "../Constants.sol";
 

--- a/contracts/libraries/SystemContractHelper.sol
+++ b/contracts/libraries/SystemContractHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import {MAX_SYSTEM_CONTRACT_ADDRESS} from "../Constants.sol";
 

--- a/contracts/libraries/SystemContractHelper.sol
+++ b/contracts/libraries/SystemContractHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import {MAX_SYSTEM_CONTRACT_ADDRESS} from "../Constants.sol";
 

--- a/contracts/libraries/SystemContractHelper.sol
+++ b/contracts/libraries/SystemContractHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import {MAX_SYSTEM_CONTRACT_ADDRESS} from "../Constants.sol";
 

--- a/contracts/libraries/SystemContractsCaller.sol
+++ b/contracts/libraries/SystemContractsCaller.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity0.8;
 
 import {MSG_VALUE_SYSTEM_CONTRACT, MSG_VALUE_SIMULATOR_IS_SYSTEM_BIT} from "../Constants.sol";
 import "./Utils.sol";

--- a/contracts/libraries/SystemContractsCaller.sol
+++ b/contracts/libraries/SystemContractsCaller.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8;
+pragma solidity 0.8.20;
 
 import {MSG_VALUE_SYSTEM_CONTRACT, MSG_VALUE_SIMULATOR_IS_SYSTEM_BIT} from "../Constants.sol";
 import "./Utils.sol";

--- a/contracts/libraries/SystemContractsCaller.sol
+++ b/contracts/libraries/SystemContractsCaller.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8;
+pragma solidity0 .8;
 
 import {MSG_VALUE_SYSTEM_CONTRACT, MSG_VALUE_SIMULATOR_IS_SYSTEM_BIT} from "../Constants.sol";
 import "./Utils.sol";

--- a/contracts/libraries/TransactionHelper.sol
+++ b/contracts/libraries/TransactionHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import "../openzeppelin/token/ERC20/IERC20.sol";
 import "../openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/libraries/TransactionHelper.sol
+++ b/contracts/libraries/TransactionHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "../openzeppelin/token/ERC20/IERC20.sol";
 import "../openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/libraries/TransactionHelper.sol
+++ b/contracts/libraries/TransactionHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import "../openzeppelin/token/ERC20/IERC20.sol";
 import "../openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/libraries/TransactionHelper.sol
+++ b/contracts/libraries/TransactionHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import "../openzeppelin/token/ERC20/IERC20.sol";
 import "../openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/libraries/UnsafeBytesCalldata.sol
+++ b/contracts/libraries/UnsafeBytesCalldata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 /**
  * @author Matter Labs

--- a/contracts/libraries/UnsafeBytesCalldata.sol
+++ b/contracts/libraries/UnsafeBytesCalldata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/libraries/UnsafeBytesCalldata.sol
+++ b/contracts/libraries/UnsafeBytesCalldata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/libraries/UnsafeBytesCalldata.sol
+++ b/contracts/libraries/UnsafeBytesCalldata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 /**
  * @author Matter Labs

--- a/contracts/libraries/Utils.sol
+++ b/contracts/libraries/Utils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0;
+pragma solidity 0.8.20;
 
 import "./EfficientCall.sol";
 

--- a/contracts/openzeppelin/token/ERC20/IERC20.sol
+++ b/contracts/openzeppelin/token/ERC20/IERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v4.6.0) (token/ERC20/IERC20.sol)
 
-pragma solidity0.8.20;
+pragma solidity ^0.8.0;
 
 /**
  * @dev Interface of the ERC20 standard as defined in the EIP.

--- a/contracts/openzeppelin/token/ERC20/IERC20.sol
+++ b/contracts/openzeppelin/token/ERC20/IERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v4.6.0) (token/ERC20/IERC20.sol)
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 /**
  * @dev Interface of the ERC20 standard as defined in the EIP.

--- a/contracts/openzeppelin/token/ERC20/IERC20.sol
+++ b/contracts/openzeppelin/token/ERC20/IERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v4.6.0) (token/ERC20/IERC20.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 /**
  * @dev Interface of the ERC20 standard as defined in the EIP.

--- a/contracts/openzeppelin/token/ERC20/extensions/IERC20Permit.sol
+++ b/contracts/openzeppelin/token/ERC20/extensions/IERC20Permit.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts v4.4.1 (token/ERC20/extensions/IERC20Permit.sol)
 
-pragma solidity0.8.20;
+pragma solidity ^0.8.0;
 
 /**
  * @dev Interface of the ERC20 Permit extension allowing approvals to be made via signatures, as defined in

--- a/contracts/openzeppelin/token/ERC20/extensions/IERC20Permit.sol
+++ b/contracts/openzeppelin/token/ERC20/extensions/IERC20Permit.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts v4.4.1 (token/ERC20/extensions/IERC20Permit.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 /**
  * @dev Interface of the ERC20 Permit extension allowing approvals to be made via signatures, as defined in

--- a/contracts/openzeppelin/token/ERC20/extensions/IERC20Permit.sol
+++ b/contracts/openzeppelin/token/ERC20/extensions/IERC20Permit.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts v4.4.1 (token/ERC20/extensions/IERC20Permit.sol)
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 /**
  * @dev Interface of the ERC20 Permit extension allowing approvals to be made via signatures, as defined in

--- a/contracts/openzeppelin/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/openzeppelin/token/ERC20/utils/SafeERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v4.8.0) (token/ERC20/utils/SafeERC20.sol)
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "../IERC20.sol";
 import "../extensions/IERC20Permit.sol";

--- a/contracts/openzeppelin/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/openzeppelin/token/ERC20/utils/SafeERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v4.8.0) (token/ERC20/utils/SafeERC20.sol)
 
-pragma solidity0.8.20;
+pragma solidity ^0.8.0;
 
 import "../IERC20.sol";
 import "../extensions/IERC20Permit.sol";

--- a/contracts/openzeppelin/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/openzeppelin/token/ERC20/utils/SafeERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v4.8.0) (token/ERC20/utils/SafeERC20.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import "../IERC20.sol";
 import "../extensions/IERC20Permit.sol";

--- a/contracts/openzeppelin/utils/Address.sol
+++ b/contracts/openzeppelin/utils/Address.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v4.8.0) (utils/Address.sol)
 
-pragma solidity ^0.8.1;
+pragma solidity ^0.8.20;
 
 /**
  * @dev Collection of functions related to the address type

--- a/contracts/openzeppelin/utils/Address.sol
+++ b/contracts/openzeppelin/utils/Address.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v4.8.0) (utils/Address.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 /**
  * @dev Collection of functions related to the address type

--- a/contracts/openzeppelin/utils/Address.sol
+++ b/contracts/openzeppelin/utils/Address.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v4.8.0) (utils/Address.sol)
 
-pragma solidity0.8.20;
+pragma solidity ^0.8.1;
 
 /**
  * @dev Collection of functions related to the address type

--- a/contracts/test-contracts/Callable.sol
+++ b/contracts/test-contracts/Callable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 contract Callable {
     event Called(uint256 value, bytes data);

--- a/contracts/test-contracts/Callable.sol
+++ b/contracts/test-contracts/Callable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 contract Callable {
     event Called(uint256 value, bytes data);

--- a/contracts/test-contracts/Callable.sol
+++ b/contracts/test-contracts/Callable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 contract Callable {
     event Called(uint256 value, bytes data);

--- a/contracts/test-contracts/Callable.sol
+++ b/contracts/test-contracts/Callable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 contract Callable {
     event Called(uint256 value, bytes data);

--- a/contracts/test-contracts/Deployable.sol
+++ b/contracts/test-contracts/Deployable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 contract Deployable {
     event Deployed(uint256 value, bytes data);

--- a/contracts/test-contracts/Deployable.sol
+++ b/contracts/test-contracts/Deployable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 contract Deployable {
     event Deployed(uint256 value, bytes data);

--- a/contracts/test-contracts/Deployable.sol
+++ b/contracts/test-contracts/Deployable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 contract Deployable {
     event Deployed(uint256 value, bytes data);

--- a/contracts/test-contracts/Deployable.sol
+++ b/contracts/test-contracts/Deployable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 contract Deployable {
     event Deployed(uint256 value, bytes data);

--- a/contracts/test-contracts/DummyUpgrade.sol
+++ b/contracts/test-contracts/DummyUpgrade.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 contract DummyUpgrade {
     event Upgraded();

--- a/contracts/test-contracts/DummyUpgrade.sol
+++ b/contracts/test-contracts/DummyUpgrade.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 contract DummyUpgrade {
     event Upgraded();

--- a/contracts/test-contracts/DummyUpgrade.sol
+++ b/contracts/test-contracts/DummyUpgrade.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 contract DummyUpgrade {
     event Upgraded();

--- a/contracts/test-contracts/DummyUpgrade.sol
+++ b/contracts/test-contracts/DummyUpgrade.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 contract DummyUpgrade {
     event Upgraded();

--- a/contracts/test-contracts/EventWriterTest.sol
+++ b/contracts/test-contracts/EventWriterTest.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 contract EventWriterTest {
     event ZeroTopics(bytes data) anonymous;

--- a/contracts/test-contracts/EventWriterTest.sol
+++ b/contracts/test-contracts/EventWriterTest.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 contract EventWriterTest {
     event ZeroTopics(bytes data) anonymous;

--- a/contracts/test-contracts/EventWriterTest.sol
+++ b/contracts/test-contracts/EventWriterTest.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 contract EventWriterTest {
     event ZeroTopics(bytes data) anonymous;

--- a/contracts/test-contracts/EventWriterTest.sol
+++ b/contracts/test-contracts/EventWriterTest.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 contract EventWriterTest {
     event ZeroTopics(bytes data) anonymous;

--- a/contracts/test-contracts/MockERC20Approve.sol
+++ b/contracts/test-contracts/MockERC20Approve.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 contract MockERC20Approve {
     event Approved(address to, uint256 value);

--- a/contracts/test-contracts/MockERC20Approve.sol
+++ b/contracts/test-contracts/MockERC20Approve.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 contract MockERC20Approve {
     event Approved(address to, uint256 value);

--- a/contracts/test-contracts/MockERC20Approve.sol
+++ b/contracts/test-contracts/MockERC20Approve.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 contract MockERC20Approve {
     event Approved(address to, uint256 value);

--- a/contracts/test-contracts/MockERC20Approve.sol
+++ b/contracts/test-contracts/MockERC20Approve.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 contract MockERC20Approve {
     event Approved(address to, uint256 value);

--- a/contracts/test-contracts/MockKnownCodesStorage.sol
+++ b/contracts/test-contracts/MockKnownCodesStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 contract MockKnownCodesStorage {
     event MockBytecodePublished(bytes32 indexed bytecodeHash);

--- a/contracts/test-contracts/MockKnownCodesStorage.sol
+++ b/contracts/test-contracts/MockKnownCodesStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 contract MockKnownCodesStorage {
     event MockBytecodePublished(bytes32 indexed bytecodeHash);

--- a/contracts/test-contracts/MockKnownCodesStorage.sol
+++ b/contracts/test-contracts/MockKnownCodesStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 contract MockKnownCodesStorage {
     event MockBytecodePublished(bytes32 indexed bytecodeHash);

--- a/contracts/test-contracts/MockKnownCodesStorage.sol
+++ b/contracts/test-contracts/MockKnownCodesStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 contract MockKnownCodesStorage {
     event MockBytecodePublished(bytes32 indexed bytecodeHash);

--- a/contracts/test-contracts/MockL1Messenger.sol
+++ b/contracts/test-contracts/MockL1Messenger.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 contract MockL1Messenger {
     event MockBytecodeL1Published(bytes32 indexed bytecodeHash);

--- a/contracts/test-contracts/MockL1Messenger.sol
+++ b/contracts/test-contracts/MockL1Messenger.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 contract MockL1Messenger {
     event MockBytecodeL1Published(bytes32 indexed bytecodeHash);

--- a/contracts/test-contracts/MockL1Messenger.sol
+++ b/contracts/test-contracts/MockL1Messenger.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 contract MockL1Messenger {
     event MockBytecodeL1Published(bytes32 indexed bytecodeHash);

--- a/contracts/test-contracts/MockL1Messenger.sol
+++ b/contracts/test-contracts/MockL1Messenger.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 contract MockL1Messenger {
     event MockBytecodeL1Published(bytes32 indexed bytecodeHash);

--- a/contracts/test-contracts/NotSystemCaller.sol
+++ b/contracts/test-contracts/NotSystemCaller.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8;
+pragma solidity0 .8;
 
 contract NotSystemCaller {
     address immutable to;

--- a/contracts/test-contracts/NotSystemCaller.sol
+++ b/contracts/test-contracts/NotSystemCaller.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8;
+pragma solidity 0.8.20;
 
 contract NotSystemCaller {
     address immutable to;

--- a/contracts/test-contracts/NotSystemCaller.sol
+++ b/contracts/test-contracts/NotSystemCaller.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity0.8;
 
 contract NotSystemCaller {
     address immutable to;

--- a/contracts/test-contracts/SystemCaller.sol
+++ b/contracts/test-contracts/SystemCaller.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8;
+pragma solidity 0.8.20;
 
 import {SystemContractsCaller} from "../libraries/SystemContractsCaller.sol";
 

--- a/contracts/test-contracts/SystemCaller.sol
+++ b/contracts/test-contracts/SystemCaller.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity0.8;
 
 import {SystemContractsCaller} from "../libraries/SystemContractsCaller.sol";
 

--- a/contracts/test-contracts/SystemCaller.sol
+++ b/contracts/test-contracts/SystemCaller.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8;
+pragma solidity0 .8;
 
 import {SystemContractsCaller} from "../libraries/SystemContractsCaller.sol";
 

--- a/contracts/test-contracts/TestSystemContract.sol
+++ b/contracts/test-contracts/TestSystemContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8 .20;
+pragma solidity 0.8.20;
 
 import "../Constants.sol";
 

--- a/contracts/test-contracts/TestSystemContract.sol
+++ b/contracts/test-contracts/TestSystemContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity0.8.20;
 
 import "../Constants.sol";
 

--- a/contracts/test-contracts/TestSystemContract.sol
+++ b/contracts/test-contracts/TestSystemContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "../Constants.sol";
 

--- a/contracts/test-contracts/TestSystemContract.sol
+++ b/contracts/test-contracts/TestSystemContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8.20;
+pragma solidity0 .8 .20;
 
 import "../Constants.sol";
 

--- a/contracts/test-contracts/TestSystemContractHelper.sol
+++ b/contracts/test-contracts/TestSystemContractHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity0.8;
 
 import {MAX_SYSTEM_CONTRACT_ADDRESS, MSG_VALUE_SYSTEM_CONTRACT} from "../Constants.sol";
 

--- a/contracts/test-contracts/TestSystemContractHelper.sol
+++ b/contracts/test-contracts/TestSystemContractHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0 .8;
+pragma solidity 0.8.20;
 
 import {MAX_SYSTEM_CONTRACT_ADDRESS, MSG_VALUE_SYSTEM_CONTRACT} from "../Constants.sol";
 

--- a/contracts/test-contracts/TestSystemContractHelper.sol
+++ b/contracts/test-contracts/TestSystemContractHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity0.8;
+pragma solidity0 .8;
 
 import {MAX_SYSTEM_CONTRACT_ADDRESS, MSG_VALUE_SYSTEM_CONTRACT} from "../Constants.sol";
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -9,7 +9,7 @@ const systemConfig = require('./SystemConfig.json');
 
 export default {
     zksolc: {
-        version: '1.3.14',
+        version: '1.3.16',
         compilerSource: 'binary',
         settings: {
             isSystem: true
@@ -20,7 +20,7 @@ export default {
         ethNetwork: 'http://localhost:8545'
     },
     solidity: {
-        version: '0.8.17',
+        version: '0.8.20',
         settings: {
             optimizer: {
                 enabled: true,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -9,7 +9,7 @@ const systemConfig = require('./SystemConfig.json');
 
 export default {
     zksolc: {
-        version: '1.3.16',
+        version: '1.3.14',
         compilerSource: 'binary',
         settings: {
             isSystem: true

--- a/scripts/compile-yul.ts
+++ b/scripts/compile-yul.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 import { getCompilersDir } from 'hardhat/internal/util/global-dir';
 import path from 'path';
 
-const COMPILER_VERSION = '1.3.14';
+const COMPILER_VERSION = '1.3.16';
 const IS_COMPILER_PRE_RELEASE = false;
 
 async function compilerLocation(): Promise<string> {

--- a/scripts/compile-yul.ts
+++ b/scripts/compile-yul.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 import { getCompilersDir } from 'hardhat/internal/util/global-dir';
 import path from 'path';
 
-const COMPILER_VERSION = '1.3.16';
+const COMPILER_VERSION = '1.3.14';
 const IS_COMPILER_PRE_RELEASE = false;
 
 async function compilerLocation(): Promise<string> {


### PR DESCRIPTION
# What ❔

Updating the hardhat version and solidity compiler versions.

## Why ❔

There was a bug found in earlier solidity versions known to have a bug in the legacy code generation pipeline, `MissingSideEffectsOnSelectorAccess`.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
