### PR TITLE
chore: create githooks to check formatting and linting 

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+RED='\033[0;31m'
+
+# Check that the code is formatted in the given directory provided in the first argument
+function check_prettier {
+    if ! yarn prettier:check; then
+        echo "${RED}Commit error! Cannot commit unformatted code!${NC}"
+        echo "Prettier errors found. Please format the code via ${CYAN}yarn prettier:fix${NC}!"
+        exit 1
+    fi
+}
+
+check_prettier

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+RED='\033[0;31m'
+
+# Checking that the code is linted and formatted in the given directory provided in the first argument
+function check_lint {
+    if ! yarn lint:check; then
+        echo "${RED}Push error! Cannot push unlinted code!${NC}"
+        echo "Lint errors found. Please lint the code via ${CYAN}yarn lint:fix${NC} and/or fix the errors manually!"
+        exit 1
+    fi
+}
+
+check_lint

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,4 +17,3 @@
 - [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
 - [ ] Tests for the changes have been added / updated.
 - [ ] Documentation comments have been added / updated.
-- [ ] Code has been linted and formatted via `yarn lint:fix`.


### PR DESCRIPTION
# What ❔
Create `pre-commit` and `pre-push` githooks for the [era-contracts](https://github.com/matter-labs/era-contracts/) and [era-system-contracts](https://github.com/matter-labs/era-system-contracts/) repositories.

Steps:
1. create a `pre-commit` hook that runs the `prettier:check` command to prohibit committing unformatted code
2. create a `pre-push` hook that runs the `lint:check` command to prohibit pushing unlinted code
3. make sure that in the[ era-system-contracts](https://github.com/matter-labs/era-system-contracts/) repository, the hooks check both the `ethereum` and `zksync` directories
4. Make sure that:
  * the hooks are added to the `.githooks` directory
  * the hooks directory is set to be `.githooks`: `git config core.hooksPath .githooks/`
  * the files named `pre-commit` and `pre-push`
  * the files are executable: `chmod +x file`

## Why ❔
Currently, the formatting and linting has to be run manually, that can be easily forgotten, create githooks that run these automatically!

## Checklist
- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] ~Tests for the changes have been added / updated.~
- [x] Documentation comments have been added / updated.
