### PR TITLE
Add missing Comments for temporary functions in Bootloader and ContractDeployer

### DIFF
--- a/bootloader/bootloader.yul
+++ b/bootloader/bootloader.yul
@@ -638,6 +638,8 @@ object "Bootloader" {
                     }
             }
 
+            /// @dev The function that is temporarily needed to upgrade the Keccak256 precompile. This function and `ContractDeployer:forceDeployKeccak256`
+            /// are to be removed once the upgrade is complete.
             /// @dev Checks whether the code hash of the Keccak256 precompile contract is correct and updates it if needed.
             /// @dev When we upgrade to the new version of the Keccak256 precompile contract, the keccak precompile will not work correctly 
             /// and so the upgrade it should be done before any `keccak` calls. 

--- a/contracts/ContractDeployer.sol
+++ b/contracts/ContractDeployer.sol
@@ -230,11 +230,11 @@ contract ContractDeployer is IContractDeployer, ISystemContract {
         );
     }
 
-    /// @notice The method that is temporarily needed to upgrade the Keccak256 precompile. It is to be removed in the 
-    /// future. Unlike a normal forced deployment, it does not update account information as it requires updating a 
-    /// mapping, and so requires Keccak256 precompile to work already.
-    /// @dev This method expects the sender (FORCE_DEPLOYER) to provide the correct bytecode hash for the Keccak256 
-    /// precompile. 
+    /// @notice The method that is temporarily needed to upgrade the Keccak256 precompile. This function and `Bootloader:upgradeKeccakIfNeeded`
+    /// are to be removed once the upgrade is complete. Unlike a normal forced deployment, it does not update account information as it requires
+    /// updating a mapping, and so requires Keccak256 precompile to work already.
+    /// @dev This method expects the sender (FORCE_DEPLOYER) to provide the correct bytecode hash for the Keccak256
+    /// precompile.
     function forceDeployKeccak256(bytes32 _keccak256BytecodeHash) external payable onlyCallFrom(FORCE_DEPLOYER) {
         _ensureBytecodeIsKnown(_keccak256BytecodeHash);
 


### PR DESCRIPTION
# What ❔

- Add a comment to the `upgradeKeccakIfNeeded` function, pointing out that it should be removed once the upgrade process is complete. 
- Add mentioning for temporary upgrade functions that their interdependent counterpart function should also be removed.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
