### PR TITLE
Add comments for keccak256 wrapper

### DIFF
--- a/contracts/precompiles/Keccak256.yul
+++ b/contracts/precompiles/Keccak256.yul
@@ -11,12 +11,21 @@ object "Keccak256" {
             //                      CONSTANTS
             ////////////////////////////////////////////////////////////////
 
-            /// @dev The size of the processing keccak256 block in bytes.
+            /// @dev Returns the block size used by the keccak256 hashing function.
+            /// The value 136 bytes corresponds to the size of the input data block that the keccak256 
+            /// algorithm processes in each round, as defined in the keccak256 specification. This is derived 
+            /// from the formula (1600 - 2 * bit length of the digest) / 8, where the bit length for keccak256
+            /// is 256 bits. For more details, refer to the Keccak specification at
+            /// https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf#page=30
             function BLOCK_SIZE() -> ret {
                 ret := 136
             }
 
             /// @dev The gas cost of processing one keccak256 round.
+            /// @dev This constant is made equal to the corresponding constant in
+            /// https://github.com/matter-labs/era-zkevm_opcode_defs/blob/v1.4.1/src/circuit_prices.rs,
+            /// which was automatically generated depending on the capacity of rounds for a 
+            /// single Keccak256 circuit.
             function KECCAK_ROUND_GAS_COST() -> ret {
                 ret := 40
             }


### PR DESCRIPTION
# What ❔

Add explanations in the comments as to how the values 136 is derived in `BLOCK_SIZE` and 40 in `KECCAK_ROUND_GAS_COST` were derived.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
