### PR TITLE
Fix incorrect calculation for required number of keccak256 hash rounds

### DIFF
--- a/contracts/precompiles/Keccak256.yul
+++ b/contracts/precompiles/Keccak256.yul
@@ -85,7 +85,7 @@ object "Keccak256" {
                 0                                 // per precompile interpreted value (0 since circuit doesn't react on this value anyway)
             )
             // 4. Calculate number of required hash rounds per calldata
-            let numRounds := div(add(ptrLength, sub(BLOCK_SIZE(), 1)), BLOCK_SIZE())
+            let numRounds := add(div(ptrLength, BLOCK_SIZE()), 1)
             let gasToPay := mul(KECCAK_ROUND_GAS_COST(), numRounds)
 
             // 5. Call precompile


### PR DESCRIPTION
# What ❔

Increase the number of hash rounds in the gas calculation per keccak256 precompile call.

## Why ❔

The number of rounds required to compute hash was incorrect for data multiples of 136. 
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
