### PR TITLE
Use compatible error codes with the previous version

### DIFF
--- a/SystemContractsHashes.json
+++ b/SystemContractsHashes.json
@@ -143,35 +143,35 @@
     "contractName": "bootloader_test",
     "bytecodePath": "bootloader/build/artifacts/bootloader_test.yul/bootloader_test.yul.zbin",
     "sourceCodePath": "bootloader/build/bootloader_test.yul",
-    "bytecodeHash": "0x01000385b945250b898a71c3d04d328afd391bf56cb391725e183c62b3bbf556",
-    "sourceCodeHash": "0x7bd3ed9d760fc72c68825b86ff175c4a5601b0d6b1eca135f8a8756786e7ea95"
+    "bytecodeHash": "0x01000385425e3ddcaa5a6780f2463c8aa71b844d914b61471f468173d7eaff0d",
+    "sourceCodeHash": "0xda28bc1ac0cd1e0a34ea99bb70cde15fd0edbacffe7491186620f46fc821c201"
   },
   {
     "contractName": "fee_estimate",
     "bytecodePath": "bootloader/build/artifacts/fee_estimate.yul/fee_estimate.yul.zbin",
     "sourceCodePath": "bootloader/build/fee_estimate.yul",
-    "bytecodeHash": "0x0100096b2cc4a11258bcf6566ecdc3af49e600b607750c4d792d49fe56597d56",
-    "sourceCodeHash": "0xe2f8836de8c5d0110081393b373ff23ddcbd014b39e4c865092236d752e43cbb"
+    "bytecodeHash": "0x0100096bebcd3abfed25138ff97587a5783c0294c25627aa4166bd1c91913a2d",
+    "sourceCodeHash": "0x6732aa11175c77394065e586f123d10a844335bc57a58ef47291de32583de225"
   },
   {
     "contractName": "gas_test",
     "bytecodePath": "bootloader/build/artifacts/gas_test.yul/gas_test.yul.zbin",
     "sourceCodePath": "bootloader/build/gas_test.yul",
-    "bytecodeHash": "0x0100094b584d299e041d0ebfed17d2bd9361aa87bcb2b3456c8849159e478d99",
-    "sourceCodeHash": "0xe7ecd7132cf527552113e3bdb30f8d61dcec39a4fe27ef31926a0b4c09b33ca1"
+    "bytecodeHash": "0x0100094b78d8a52b54f82e4f1007a1c0c9ae7e2d54e73321549d7a70bb320bbf",
+    "sourceCodeHash": "0x68f07a46c3179705047c41b63b03e157fa48b0f06427801bedc8d45e335ea7c3"
   },
   {
     "contractName": "playground_batch",
     "bytecodePath": "bootloader/build/artifacts/playground_batch.yul/playground_batch.yul.zbin",
     "sourceCodePath": "bootloader/build/playground_batch.yul",
-    "bytecodeHash": "0x01000975ebcb5e5fb67155058890a8286540a76ec01a57a582342832a8e56e79",
-    "sourceCodeHash": "0x6f154f3e3b6a15a8188d850d2d6e6e6fed140926799540c4b3352d7c242ed175"
+    "bytecodeHash": "0x0100097500c0f3cc64c09339b8215f35ebdf155f2c7188b4b9426cd8d58b80cc",
+    "sourceCodeHash": "0x5a121577cd4335105a6b9864196ecb5796890299fac95e7003d9f23bd210e907"
   },
   {
     "contractName": "proved_batch",
     "bytecodePath": "bootloader/build/artifacts/proved_batch.yul/proved_batch.yul.zbin",
     "sourceCodePath": "bootloader/build/proved_batch.yul",
-    "bytecodeHash": "0x01000965d96c3603e367690834b099353216bc57910f65d230036ea3d6f21942",
-    "sourceCodeHash": "0xee74d5fe188640d88ff798813742834bc4d2a762f6ebe88c7f3f5871d281ffd0"
+    "bytecodeHash": "0x010009657432df24acfe7950b2d1a0707520ca6b7acb699e58c0f378c0ed7a11",
+    "sourceCodeHash": "0x2469138639d133005f6d3b7fad3d7404db5b4088b2649e9f5167d2a22df3b1de"
   }
 ]

--- a/bootloader/bootloader.yul
+++ b/bootloader/bootloader.yul
@@ -3465,19 +3465,19 @@ object "Bootloader" {
                 ret := 25
             }
 
-            function L1_MESSENGER_PUBLISHING_FAILED_ERR_CODE() -> ret {
+            function FAILED_TO_PUBLISH_TIMESTAMP_DATA_TO_L1() -> ret {
                 ret := 26
             }
 
-            function L1_MESSENGER_LOG_SENDING_FAILED_ERR_CODE() -> ret {
+            function L1_MESSENGER_PUBLISHING_FAILED_ERR_CODE() -> ret {
                 ret := 27
             }
 
-            function FAILED_TO_CALL_SYSTEM_CONTEXT_ERR_CODE() -> ret {
+            function L1_MESSENGER_LOG_SENDING_FAILED_ERR_CODE() -> ret {
                 ret := 28
             }
 
-            function FAILED_TO_PUBLISH_TIMESTAMP_DATA_TO_L1() -> ret {
+            function FAILED_TO_CALL_SYSTEM_CONTEXT_ERR_CODE() -> ret {
                 ret := 29
             }
 


### PR DESCRIPTION
# What ❔

Changing some of the error codes

## Why ❔

To keep the error codes backwards compatible with the previous version

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
